### PR TITLE
AD-1099: Add instance to cluster

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1981,11 +1981,12 @@
                 },
                 {
                     "command": "aws.docdb.startCluster",
-                    "when": "viewItem == DBClusterStoppedNode"
+                    "when": "viewItem =~ /^awsDocDB.cluster.stopped/"
                 },
                 {
                     "command": "aws.docdb.stopCluster",
-                    "when": "viewItem == DBClusterRunningNode"
+                    "when": "viewItem =~ /^awsDocDB.cluster.running/"
+                },
                 }
             ],
             "aws.toolkit.auth": [
@@ -3547,14 +3548,14 @@
                 "title": "%AWS.command.docdb.startCluster%",
                 "icon": "$(debug-start)",
                 "category": "%AWS.title%",
-                "enablement": "!aws.isWebExtHost && viewItem == DBClusterStoppedNode"
+                "enablement": "!aws.isWebExtHost && viewItem == awsDocDB.cluster.stopped"
             },
             {
                 "command": "aws.docdb.stopCluster",
                 "title": "%AWS.command.docdb.stopCluster%",
                 "icon": "$(debug-stop)",
                 "category": "%AWS.title%",
-                "enablement": "!aws.isWebExtHost && viewItem == DBClusterRunningNode"
+                "enablement": "!aws.isWebExtHost && viewItem =~ /^awsDocDB.cluster.running/"
             }
         ],
         "jsonValidation": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1987,6 +1987,9 @@
                     "command": "aws.docdb.stopCluster",
                     "when": "viewItem =~ /^awsDocDB.cluster.running/"
                 },
+                {
+                    "command": "aws.docdb.createInstance",
+                    "when": "viewItem == awsDocDB.cluster.running"
                 }
             ],
             "aws.toolkit.auth": [
@@ -3534,6 +3537,18 @@
             {
                 "command": "aws.docdb.createCluster",
                 "title": "%AWS.command.docdb.createCluster%",
+                "icon": "$(add)",
+                "category": "%AWS.title%",
+                "enablement": "isCloud9 || !aws.isWebExtHost",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.docdb.createInstance",
+                "title": "%AWS.command.docdb.createInstance%",
                 "icon": "$(add)",
                 "category": "%AWS.title%",
                 "enablement": "isCloud9 || !aws.isWebExtHost",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -263,6 +263,7 @@
     "AWS.amazonq.toggleCodeSuggestion": "Toggle Auto-Suggestions",
     "AWS.amazonq.toggleCodeScan": "Toggle Auto-Scans",
     "AWS.command.docdb.createCluster": "Create DocumentDB Cluster",
+    "AWS.command.docdb.createInstance": "Create Instance",
     "AWS.command.docdb.startCluster": "Start Cluster",
     "AWS.command.docdb.stopCluster": "Stop Cluster"
 }

--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -6,7 +6,9 @@
 import { Commands } from '../shared'
 import { ExtContext } from '../shared/extensions'
 import { DBNode, DocumentDBNode } from './explorer/docdbNode'
+import { DBClusterNode } from './explorer/dbClusterNode'
 import { createCluster } from './commands/createCluster'
+import { createInstance } from './commands/createInstance'
 import { startCluster, stopCluster } from './commands/commands'
 
 /**
@@ -25,6 +27,10 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
         Commands.register('aws.docdb.stopCluster', async (node?: DBNode) => {
             await stopCluster(node)
+        }),
+
+        Commands.register('aws.docdb.createInstance', async (node: DBClusterNode) => {
+            await createInstance(node)
         })
     )
 }

--- a/packages/core/src/docdb/commands/createInstance.ts
+++ b/packages/core/src/docdb/commands/createInstance.ts
@@ -1,0 +1,96 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from '../../shared'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { DBClusterNode } from '../explorer/dbClusterNode'
+import { CreateInstanceWizard } from '../wizards/createInstanceWizard'
+import { CreateDBInstanceMessage } from '@aws-sdk/client-docdb'
+
+const MaxInstanceCount = 16
+
+/**
+ * Creates a DocumentDB instance.
+ *
+ * Prompts the user for the instance name and class.
+ * Creates the instance.
+ * Refreshes the cluster node.
+ */
+export async function createInstance(node: DBClusterNode) {
+    getLogger().debug('CreateInstance called for: %O', node)
+
+    if (!node) {
+        throw new Error('No node specified for CreateInstance')
+    }
+
+    const instances = await node.client.listInstances([node.arn])
+    if (instances.length >= MaxInstanceCount) {
+        void vscode.window.showInformationMessage(
+            localize('AWS.docdb.createInstance.limitReached', 'Max instances in use')
+        )
+        return
+    }
+    if (node.status !== 'available') {
+        void vscode.window.showInformationMessage(
+            localize('AWS.docdb.createInstance.clusterStopped', 'Cluster must be started to create instances')
+        )
+        return
+    }
+
+    const generateInstanceName = (clusterName: string) =>
+        instances.length === 0 ? clusterName : `${clusterName}${++instances.length}`
+
+    const options = {
+        implicitState: {
+            DBInstanceIdentifier: generateInstanceName(node.cluster.DBClusterIdentifier!),
+            DBInstanceClass: instances[0]?.DBInstanceClass,
+        },
+    }
+    const wizard = new CreateInstanceWizard(node.regionCode, node.cluster, options, node.client)
+
+    const result = await wizard.run()
+
+    if (!result) {
+        getLogger().info('CreateInstance cancelled')
+        return
+    }
+
+    if (result.DBInstanceIdentifier === '') {
+        result.DBInstanceIdentifier = undefined!
+    }
+
+    if (result.DBInstanceClass === '') {
+        result.DBInstanceClass = undefined!
+    }
+
+    const instanceName = result.DBInstanceIdentifier
+    getLogger().info(`Creating instance: ${instanceName}`)
+
+    try {
+        const request: CreateDBInstanceMessage = {
+            Engine: 'docdb',
+            DBClusterIdentifier: node.cluster.DBClusterIdentifier,
+            DBInstanceIdentifier: result.DBInstanceIdentifier,
+            DBInstanceClass: result.DBInstanceClass,
+        }
+
+        const instance = await node.createInstance(request)
+
+        getLogger().info('Created instance: %O', instance)
+        void vscode.window.showInformationMessage(
+            localize('AWS.docdb.createInstance.success', 'Creating instance: {0}', instanceName)
+        )
+
+        node.refresh()
+        return instance
+    } catch (e) {
+        getLogger().error(`Failed to create instance ${instanceName}: %s`, e)
+        void showViewLogsMessage(
+            localize('AWS.docdb.createInstance.error', 'Failed to create instance: {0}', instanceName)
+        )
+    }
+}

--- a/packages/core/src/docdb/explorer/dbClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbClusterNode.ts
@@ -14,13 +14,7 @@ import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { DBInstanceNode } from './dbInstanceNode'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { DBInstance, DocumentDBClient } from '../../shared/clients/docdbClient'
-import { DocumentDBNode } from './docdbNode'
-
-export const DBClusterRunningContext = 'DBClusterRunningNode'
-export const DBClusterStoppedContext = 'DBClusterStoppedNode'
-export const DBClusterPendingContext = 'DBClusterPendingNode'
-
-export type DBClusterNodeContext = 'DBClusterRunningNode' | 'DBClusterStoppedNode' | 'DBClusterPendingNode'
+import { DocDBContext, DocDBNodeContext, DocumentDBNode } from './docdbNode'
 
 /**
  * An AWS Explorer node representing DocumentDB clusters.
@@ -64,17 +58,17 @@ export class DBClusterNode extends AWSTreeNodeBase implements AWSResourceNode {
         })
     }
 
-    private getContext(): DBClusterNodeContext {
+    private getContext(): DocDBNodeContext {
         if (this.status === 'available') {
-            return DBClusterRunningContext
+            return DocDBContext.ClusterRunning
         } else if (this.status === 'stopped') {
-            return DBClusterStoppedContext
+            return DocDBContext.ClusterStopped
         }
-        return DBClusterPendingContext
+        return DocDBContext.Cluster
     }
 
     public getDescription(): string | boolean {
-        if (this.contextValue !== (DBClusterRunningContext as string)) {
+        if (this.contextValue !== (DocDBContext.ClusterRunning as string)) {
             return this.status!
         }
         return false

--- a/packages/core/src/docdb/explorer/dbClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbClusterNode.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { inspect } from 'util'
 import { makeChildrenNodes } from '../../shared/treeview/utils'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { DBCluster } from '@aws-sdk/client-docdb'
+import { CreateDBInstanceMessage, DBCluster } from '@aws-sdk/client-docdb'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { DBInstanceNode } from './dbInstanceNode'
@@ -72,6 +72,10 @@ export class DBClusterNode extends AWSTreeNodeBase implements AWSResourceNode {
             return this.status!
         }
         return false
+    }
+
+    public async createInstance(request: CreateDBInstanceMessage): Promise<DBInstance | undefined> {
+        return await this.client.createInstance(request)
     }
 
     public get status(): string | undefined {

--- a/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
@@ -8,13 +8,7 @@ import { inspect } from 'util'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { DBElasticCluster, DocumentDBClient } from '../../shared/clients/docdbClient'
-import {
-    DBClusterNodeContext,
-    DBClusterPendingContext,
-    DBClusterRunningContext,
-    DBClusterStoppedContext,
-} from './dbClusterNode'
-import { DocumentDBNode } from './docdbNode'
+import { DocDBContext, DocDBNodeContext, DocumentDBNode } from './docdbNode'
 
 /**
  * An AWS Explorer node representing DocumentDB elastic clusters.
@@ -38,17 +32,17 @@ export class DBElasticClusterNode extends AWSTreeNodeBase implements AWSResource
         this.tooltip = `${this.name}\nStatus: ${this.status}`
     }
 
-    private getContext(): DBClusterNodeContext {
+    private getContext(): DocDBNodeContext {
         if (this.status === 'active') {
-            return DBClusterRunningContext
+            return DocDBContext.ClusterRunning
         } else if (this.status === 'stopped') {
-            return DBClusterStoppedContext
+            return DocDBContext.ClusterStopped
         }
-        return DBClusterPendingContext
+        return DocDBContext.Cluster
     }
 
     public getDescription(): string | boolean {
-        if (this.contextValue !== (DBClusterRunningContext as string)) {
+        if (this.contextValue !== (DocDBContext.ClusterRunning as string)) {
             return this.status!
         }
         return false

--- a/packages/core/src/docdb/explorer/dbInstanceNode.ts
+++ b/packages/core/src/docdb/explorer/dbInstanceNode.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import { inspect } from 'util'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { DBInstance } from '../../shared/clients/docdbClient'
-import { DBNode } from './docdbNode'
+import { DBNode, DocDBContext } from './docdbNode'
 
 /**
  * An AWS Explorer node representing a DocumentDB instance.
@@ -18,7 +18,7 @@ export class DBInstanceNode extends AWSTreeNodeBase {
     constructor(public readonly parent: DBNode, readonly instance: DBInstance) {
         super(instance.DBInstanceIdentifier ?? '[Instance]', vscode.TreeItemCollapsibleState.None)
         this.description = this.makeDescription()
-        this.contextValue = 'awsDocDBInstanceNode'
+        this.contextValue = DocDBContext.Instance
     }
 
     private makeDescription(): string {

--- a/packages/core/src/docdb/explorer/docdbNode.ts
+++ b/packages/core/src/docdb/explorer/docdbNode.ts
@@ -17,6 +17,15 @@ import { CreateDBClusterMessage, DBCluster } from '@aws-sdk/client-docdb'
 
 export type DBNode = DBClusterNode | DBElasticClusterNode | DBInstanceNode
 
+export const DocDBContext = {
+    Cluster: 'awsDocDB.cluster',
+    ClusterRunning: 'awsDocDB.cluster.running',
+    ClusterStopped: 'awsDocDB.cluster.stopped',
+    Instance: 'awsDocDB.instance',
+} as const
+
+export type DocDBNodeContext = (typeof DocDBContext)[keyof typeof DocDBContext]
+
 /**
  * An AWS Explorer node representing DocumentDB.
  *

--- a/packages/core/src/docdb/utils.ts
+++ b/packages/core/src/docdb/utils.ts
@@ -91,3 +91,40 @@ export function validatePassword(password: string): string | undefined {
 
     return undefined
 }
+
+/**
+ * Validates an instance name for the CreateInstance API.
+ * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/docdb/command/CreateDBInstanceCommand/
+ * @returns undefined if the name passes validation. Otherwise, an error message is returned.
+ */
+export function validateInstanceName(name: string): string | undefined {
+    if (name.length < 1 || name.length > 63) {
+        return localize(
+            'AWS.docdb.validateInstanceName.error.invalidLength',
+            'Instance name must be between 1 and 63 characters long'
+        )
+    }
+
+    if (!/^[a-z]/.test(name)) {
+        return localize(
+            'AWS.docdb.validateInstanceName.error.invalidStart',
+            'Instance name must start with a lowercase letter'
+        )
+    }
+
+    if (/-$/.test(name) || /--/.test(name)) {
+        return localize(
+            'AWS.docdb.validateInstanceName.error.invalidEnd',
+            'Instance name cannot end with a hyphen or contain 2 consecutive hyphens'
+        )
+    }
+
+    if (!/^[a-z0-9\-]+$/.test(name)) {
+        return localize(
+            'AWS.docdb.validateInstanceName.error.invalidCharacters',
+            'Instance name must only contain lowercase letters, numbers, and hyphens'
+        )
+    }
+
+    return undefined
+}

--- a/packages/core/src/docdb/wizards/createClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/createClusterWizard.ts
@@ -15,7 +15,7 @@ import { createCommonButtons } from '../../shared/ui/buttons'
 
 const DocDBHelpUrl = 'https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameters.html'
 
-export interface CreateWizardState extends CreateDBClusterMessage {
+export interface CreateClusterState extends CreateDBClusterMessage {
     // Required fields
     readonly DBClusterIdentifier: string
     readonly Engine: 'docdb'
@@ -32,11 +32,11 @@ export interface CreateWizardState extends CreateDBClusterMessage {
 /**
  * A wizard to prompt configuration of a new cluster
  */
-export class CreateClusterWizard extends Wizard<CreateWizardState> {
+export class CreateClusterWizard extends Wizard<CreateClusterState> {
     title: string
     constructor(
         region: string,
-        options: WizardOptions<CreateWizardState> = {},
+        options: WizardOptions<CreateClusterState> = {},
         readonly client: DocumentDBClient = new DefaultDocumentDBClient(region)
     ) {
         super({

--- a/packages/core/src/docdb/wizards/createInstanceWizard.ts
+++ b/packages/core/src/docdb/wizards/createInstanceWizard.ts
@@ -1,0 +1,95 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DBCluster, OrderableDBInstanceOption } from '@aws-sdk/client-docdb'
+import { DefaultDocumentDBClient, DocumentDBClient, DBStorageType } from '../../shared/clients/docdbClient'
+import { validateInstanceName } from '../utils'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Wizard, WizardOptions } from '../../shared/wizards/wizard'
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { createExitPrompter } from '../../shared/ui/common/exitPrompter'
+import { DataQuickPickItem, createQuickPick } from '../../shared/ui/pickerPrompter'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { SkipPrompter } from '../../shared/ui/common/skipPrompter'
+
+const DocDBHelpUrl = 'https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instances.html'
+
+export interface CreateInstanceState {
+    DBInstanceIdentifier: string
+    DBInstanceClass: string
+}
+
+/**
+ * A wizard to prompt configuration of a new instance
+ */
+export class CreateInstanceWizard extends Wizard<CreateInstanceState> {
+    title: string
+    cluster: DBCluster
+    constructor(
+        region: string,
+        cluster: DBCluster,
+        options: WizardOptions<CreateInstanceState> = {},
+        readonly client: DocumentDBClient = new DefaultDocumentDBClient(region)
+    ) {
+        super({
+            initState: {
+                ...options.initState,
+            },
+            implicitState: options.implicitState,
+            exitPrompterProvider: createExitPrompter,
+        })
+        this.cluster = cluster
+        this.client = client
+        this.title = localize('AWS.docdb.createInstance.title', 'Create Instance')
+    }
+
+    public override async init(): Promise<this> {
+        const form = this.form
+
+        form.DBInstanceIdentifier.bindPrompter(() =>
+            createInputBox({
+                step: 1,
+                title: this.title,
+                placeholder: localize('AWS.docdb.createInstance.name.prompt', 'Specify a unique instance name'),
+                validateInput: validateInstanceName,
+            })
+        )
+
+        form.DBInstanceClass.bindPrompter(async state => await this.createInstanceClassPrompter(state.stepCache))
+
+        return this
+    }
+
+    private async createInstanceClassPrompter(cache: { [key: string]: any }) {
+        const cachedOptions: OrderableDBInstanceOption[] = cache[this.client.regionCode]
+        const options =
+            cachedOptions ??
+            (await this.client.listInstanceClassOptions(
+                this.cluster.EngineVersion,
+                this.cluster.StorageType ?? DBStorageType.Standard
+            ))
+        cache[this.client.regionCode] = options
+
+        const items: DataQuickPickItem<string>[] = options.map(option => {
+            return {
+                data: option.DBInstanceClass,
+                label: option.DBInstanceClass ?? '(unknown)',
+                description: undefined,
+                detail: undefined,
+                recentlyUsed: false,
+            }
+        })
+
+        if (items.length === 0) {
+            return new SkipPrompter('')
+        }
+
+        return createQuickPick(items, {
+            step: 2,
+            title: localize('AWS.docdb.createInstance.instanceClass.prompt', 'Select instance class'),
+            buttons: createCommonButtons(DocDBHelpUrl),
+        })
+    }
+}

--- a/packages/core/src/test/docdb/commands/createInstance.test.ts
+++ b/packages/core/src/test/docdb/commands/createInstance.test.ts
@@ -1,0 +1,143 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import * as sinon from 'sinon'
+import * as vscode from 'vscode'
+import { getTestWindow } from '../../shared/vscode/window'
+import { DocumentDBClient, DBStorageType } from '../../../shared/clients/docdbClient'
+import { DBClusterNode } from '../../../docdb/explorer/dbClusterNode'
+import { createInstance } from '../../../docdb/commands/createInstance'
+import { CreateDBInstanceMessage, DBCluster } from '@aws-sdk/client-docdb'
+import { DocumentDBNode } from '../../../docdb/explorer/docdbNode'
+
+describe('createInstanceCommand', function () {
+    const clusterName = 'docdb-1234'
+    const instanceName = 'test-instance'
+    let docdb: DocumentDBClient
+    let cluster: DBCluster
+    let node: DBClusterNode
+    let sandbox: sinon.SinonSandbox
+    let spyExecuteCommand: sinon.SinonSpy
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+        spyExecuteCommand = sandbox.spy(vscode.commands, 'executeCommand')
+
+        docdb = { regionCode: 'us-east-1' } as DocumentDBClient
+        docdb.listInstances = sinon.stub().resolves([])
+        docdb.listInstanceClassOptions = sinon
+            .stub()
+            .resolves([{ DBInstanceClass: 'db.t3.medium', StorageType: DBStorageType.Standard }])
+
+        cluster = { DBClusterIdentifier: clusterName, Status: 'available' }
+        const parentNode = new DocumentDBNode(docdb)
+        node = new DBClusterNode(parentNode, cluster, docdb)
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+        getTestWindow().dispose()
+    })
+
+    function setupWizard() {
+        getTestWindow().onDidShowInputBox(input => {
+            input.acceptValue(instanceName)
+        })
+
+        getTestWindow().onDidShowQuickPick(async picker => {
+            await picker.untilReady()
+            picker.acceptItem(picker.items[0])
+        })
+    }
+
+    it('prompts for instance name and instance class, creates instance, shows success, and refreshes node', async function () {
+        // arrange
+        const stub = sinon.stub().resolves({
+            DBInstanceIdentifier: instanceName,
+        })
+        docdb.createInstance = stub
+        setupWizard()
+
+        // act
+        await createInstance(node)
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertInfo(/Creating instance: test-instance/)
+
+        const expectedArgs: CreateDBInstanceMessage = {
+            Engine: 'docdb',
+            DBClusterIdentifier: clusterName,
+            DBInstanceIdentifier: instanceName,
+            DBInstanceClass: 'db.t3.medium',
+        }
+
+        assert(stub.calledOnceWithExactly(expectedArgs))
+        sandbox.assert.calledWith(spyExecuteCommand, 'aws.refreshAwsExplorerNode', node)
+        assert((docdb.listInstances as sinon.SinonSpy).calledOnce)
+    })
+
+    it('does nothing when prompt is cancelled', async function () {
+        // arrange
+        const stub = sinon.stub()
+        docdb.createInstance = stub
+        getTestWindow().onDidShowInputBox(input => input.hide())
+
+        // act
+        await createInstance(node)
+
+        // assert
+        assert(stub.notCalled)
+    })
+
+    it('shows a warning when the cluster has the max number of instances', async function () {
+        // arrange
+        docdb.listInstances = sinon.stub().resolves(new Array(16))
+        const stub = sinon.stub()
+        docdb.createInstance = stub
+        setupWizard()
+
+        // act
+        await createInstance(node)
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertMessage(/Max instances in use/)
+    })
+
+    it('shows a warning when the cluster is stopped', async function () {
+        // arrange
+        cluster.Status = 'stopped'
+        const stub = sinon.stub()
+        docdb.createInstance = stub
+        setupWizard()
+
+        // act
+        await createInstance(node)
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertMessage(/Cluster must be started to create instances/)
+    })
+
+    it('shows an error when instance creation fails', async function () {
+        // arrange
+        const stub = sinon.stub().rejects()
+        docdb.createInstance = stub
+        setupWizard()
+
+        // act
+        await createInstance(node)
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertError(/Failed to create instance: test-instance/)
+    })
+})

--- a/packages/core/src/test/docdb/utils.test.ts
+++ b/packages/core/src/test/docdb/utils.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { validateClusterName, validatePassword, validateUsername } from '../../docdb/utils'
+import { validateClusterName, validateInstanceName, validatePassword, validateUsername } from '../../docdb/utils'
 
 describe('validateClusterName', function () {
     it('Validates cluster name is not blank', function () {
@@ -96,6 +96,43 @@ describe('validatePassword', function () {
 
     it('Allows passwords with printable ASCII characters', function () {
         const message = validatePassword('passw0rd |~')
+        assert.strictEqual(message, undefined)
+    })
+})
+
+describe('validateInstanceName', function () {
+    it('Validates instance name is not blank', function () {
+        const message = validateInstanceName('')
+        assert.strictEqual(message, 'Instance name must be between 1 and 63 characters long')
+    })
+
+    it('Validates instance name is not too long', function () {
+        const message = validateInstanceName('c'.repeat(64))
+        assert.strictEqual(message, 'Instance name must be between 1 and 63 characters long')
+    })
+
+    it('Validates instance name starts with a lowercase letter', function () {
+        const message = validateInstanceName('404')
+        assert.strictEqual(message, 'Instance name must start with a lowercase letter')
+    })
+
+    it('Validates instance name does not contain uppercase characters', function () {
+        const message = validateInstanceName('abcDEF')
+        assert.strictEqual(message, 'Instance name must only contain lowercase letters, numbers, and hyphens')
+    })
+
+    it('Validates instance name does not end with a dash', function () {
+        const message = validateInstanceName('abc-')
+        assert.strictEqual(message, 'Instance name cannot end with a hyphen or contain 2 consecutive hyphens')
+    })
+
+    it("Validates instance name does not contain '--'", function () {
+        const message = validateInstanceName('a--b')
+        assert.strictEqual(message, 'Instance name cannot end with a hyphen or contain 2 consecutive hyphens')
+    })
+
+    it('Allows lowercase names with numbers and dashes', function () {
+        const message = validateInstanceName('a-2')
         assert.strictEqual(message, undefined)
     })
 })


### PR DESCRIPTION
Add menu action command to add an instance to a regional cluster.

- Refactored node context values to support expression matching
- Add sdk client methods
- Register command / menu with vscode
- Add wizard
- Implement logic