### PR TITLE
AD-1112: Add delete cluster command

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1988,6 +1988,10 @@
                     "when": "viewItem =~ /^awsDocDB.cluster.running/"
                 },
                 {
+                    "command": "aws.docdb.deleteCluster",
+                    "when": "viewItem =~ /^awsDocDB.cluster.running/"
+                },
+                {
                     "command": "aws.docdb.createInstance",
                     "when": "viewItem == awsDocDB.cluster.running"
                 },
@@ -3586,6 +3590,17 @@
                 "icon": "$(debug-stop)",
                 "category": "%AWS.title%",
                 "enablement": "!aws.isWebExtHost && viewItem =~ /^awsDocDB.cluster.running/"
+            },
+            {
+                "command": "aws.docdb.deleteCluster",
+                "title": "%AWS.command.docdb.deleteCluster%",
+                "category": "%AWS.title%",
+                "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB.cluster.running/",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             }
         ],
         "jsonValidation": [

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -266,5 +266,6 @@
     "AWS.command.docdb.createInstance": "Create Instance",
     "AWS.command.docdb.deleteInstance": "Delete Instance",
     "AWS.command.docdb.startCluster": "Start Cluster",
-    "AWS.command.docdb.stopCluster": "Stop Cluster"
+    "AWS.command.docdb.stopCluster": "Stop Cluster",
+    "AWS.command.docdb.deleteCluster": "Delete Cluster"
 }

--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -10,6 +10,7 @@ import { DBClusterNode } from './explorer/dbClusterNode'
 import { DBInstanceNode } from './explorer/dbInstanceNode'
 import { createCluster } from './commands/createCluster'
 import { createInstance } from './commands/createInstance'
+import { deleteCluster } from './commands/deleteCluster'
 import { deleteInstance } from './commands/deleteInstance'
 import { startCluster, stopCluster } from './commands/commands'
 
@@ -29,6 +30,10 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
         Commands.register('aws.docdb.stopCluster', async (node?: DBNode) => {
             await stopCluster(node)
+        }),
+
+        Commands.register('aws.docdb.deleteCluster', async (node: DBClusterNode) => {
+            await deleteCluster(node)
         }),
 
         Commands.register('aws.docdb.createInstance', async (node: DBClusterNode) => {

--- a/packages/core/src/docdb/commands/deleteCluster.ts
+++ b/packages/core/src/docdb/commands/deleteCluster.ts
@@ -1,0 +1,104 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from '../../shared'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { DBClusterNode } from '../explorer/dbClusterNode'
+import { showQuickPick } from '../../shared/ui/pickerPrompter'
+import { formatDate, formatTime } from '../utils'
+
+/**
+ * Deletes a DocumentDB cluster.
+ *
+ * Prompts the user for confirmation, and whether to keep a snapshot
+ * Deletes the cluster and all instances.
+ * Refreshes the cluster node.
+ */
+export async function deleteCluster(node: DBClusterNode) {
+    getLogger().debug('DeleteCluster called for: %O', node)
+
+    if (!node) {
+        throw new Error('No node specified for DeleteCluster')
+    }
+
+    const clusterName = node.cluster.DBClusterIdentifier!
+
+    if (node.cluster.DeletionProtection) {
+        void vscode.window.showErrorMessage(
+            localize(
+                'AWS.docdb.deleteCluster.protected',
+                'Clusters cannot be deleted while deletion protection is enabled'
+            )
+        )
+        return
+    }
+
+    if (node.status !== 'available') {
+        void vscode.window.showErrorMessage(
+            localize('AWS.docdb.deleteCluster.clusterStopped', 'Cluster must be running')
+        )
+        return
+    }
+
+    const takeSnapshot = await showQuickPick(
+        [
+            { label: localize('AWS.generic.response.yes', 'Yes'), data: true },
+            { label: localize('AWS.generic.response.no', 'No'), data: false },
+        ],
+        {
+            title: localize('AWS.docdb.deleteCluster.promptSnapshot', 'Delete Cluster - Keep a snapshot of the data?'),
+        }
+    )
+    if (takeSnapshot === undefined) {
+        getLogger().info('DeleteCluster cancelled')
+        return
+    }
+
+    const isConfirmed = await showConfirmationDialog()
+    if (!isConfirmed) {
+        getLogger().info('DeleteCluster cancelled')
+        return
+    }
+
+    try {
+        getLogger().info(`Deleting cluster: ${clusterName}`)
+
+        let finalSnapshotId: string | undefined = undefined
+        if (takeSnapshot) {
+            const timestamp = `${formatDate()}-${formatTime()}`
+            finalSnapshotId = `${clusterName}-${timestamp}`
+        }
+
+        const cluster = await node.deleteCluster(finalSnapshotId)
+
+        getLogger().info('Deleted cluster: %O', cluster)
+        void vscode.window.showInformationMessage(
+            localize('AWS.docdb.deleteCluster.success', 'Deleting cluster: {0}', clusterName)
+        )
+
+        await node.waitUntilStatusChanged()
+        node.refresh()
+        return cluster
+    } catch (e) {
+        getLogger().error(`Failed to delete cluster ${clusterName}: %s`, e)
+        void showViewLogsMessage(
+            localize('AWS.docdb.deleteCluster.error', 'Failed to delete cluster: {0}', clusterName)
+        )
+    }
+}
+
+async function showConfirmationDialog(): Promise<boolean> {
+    const prompt = localize('AWS.docdb.deleteCluster.prompt', "Enter 'delete entire cluster' to confirm deletion")
+    const confirmValue = localize('AWS.docdb.deleteCluster.confirmValue', 'delete entire cluster').toLowerCase()
+    const confirmationInput = await vscode.window.showInputBox({
+        prompt,
+        placeHolder: confirmValue,
+        validateInput: input => (input?.toLowerCase() !== confirmValue ? prompt : undefined),
+    })
+
+    return confirmationInput === confirmValue
+}

--- a/packages/core/src/docdb/commands/deleteInstance.ts
+++ b/packages/core/src/docdb/commands/deleteInstance.ts
@@ -28,16 +28,6 @@ export async function deleteInstance(node: DBInstanceNode) {
     const client = parent.client
     const instanceName = node.instance.DBInstanceIdentifier!
 
-    if (parent?.cluster.DeletionProtection) {
-        void vscode.window.showErrorMessage(
-            localize(
-                'AWS.docdb.deleteInstance.protected',
-                'Instances cannot be deleted while deletion protection is enabled'
-            )
-        )
-        return
-    }
-
     if (node.instance.DBInstanceStatus !== 'available') {
         void vscode.window.showErrorMessage(
             localize('AWS.docdb.deleteInstance.instanceStopped', 'Instance must be running')

--- a/packages/core/src/docdb/utils.ts
+++ b/packages/core/src/docdb/utils.ts
@@ -128,3 +128,22 @@ export function validateInstanceName(name: string): string | undefined {
 
     return undefined
 }
+
+/**
+ * Format for rendering readable dates as YYYY-MM-DD
+ */
+export function formatDate(date: Date = new Date()): string {
+    const year = date.getFullYear()
+    const month = (date.getMonth() + 1).toString().padStart(2, '0')
+    const day = date.getDate().toString().padStart(2, '0')
+    return `${year}-${month}-${day}`
+}
+
+/**
+ * Format for rendering the time as HH:mm
+ */
+export function formatTime(date: Date = new Date()): string {
+    const hours = date.getHours().toString().padStart(2, '0')
+    const minutes = date.getMinutes().toString().padStart(2, '0')
+    return `${hours}${minutes}`
+}

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -64,6 +64,8 @@ export class DefaultDocumentDBClient {
             return response.DBEngineVersions ?? []
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to get DocumentDB engine versions')
+        } finally {
+            client.destroy()
         }
     }
 
@@ -89,6 +91,8 @@ export class DefaultDocumentDBClient {
             return instanceClasses.filter(ic => storageType === ic.StorageType || storageType === undefined)
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to get instance classes')
+        } finally {
+            client.destroy()
         }
     }
 
@@ -105,6 +109,8 @@ export class DefaultDocumentDBClient {
             return response.DBClusters ?? []
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to get DocumentDB clusters')
+        } finally {
+            client.destroy()
         }
     }
 
@@ -122,6 +128,8 @@ export class DefaultDocumentDBClient {
             return response.DBInstances ?? []
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to get DocumentDB instances')
+        } finally {
+            client.destroy()
         }
     }
 
@@ -135,6 +143,8 @@ export class DefaultDocumentDBClient {
             return response.clusters ?? []
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to get DocumentDB elastic clusters')
+        } finally {
+            client.destroy()
         }
     }
 
@@ -148,6 +158,8 @@ export class DefaultDocumentDBClient {
             return response.DBCluster
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to create DocumentDB cluster')
+        } finally {
+            client.destroy()
         }
     }
 
@@ -195,6 +207,8 @@ export class DefaultDocumentDBClient {
             return response.DBInstance
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to create DocumentDB instance')
+        } finally {
+            client.destroy()
         }
     }
 
@@ -208,6 +222,8 @@ export class DefaultDocumentDBClient {
             return response.DBInstance
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to delete DocumentDB instance')
+        } finally {
+            client.destroy()
         }
     }
 }

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -96,13 +96,14 @@ export class DefaultDocumentDBClient {
         }
     }
 
-    public async listClusters(): Promise<DocDB.DBCluster[]> {
+    public async listClusters(clusterId: string | undefined = undefined): Promise<DocDB.DBCluster[]> {
         getLogger().debug('ListClusters called')
         const client = await this.getClient()
 
         try {
-            const input = {
+            const input: DocDB.DescribeDBClustersCommandInput = {
                 Filters: [{ Name: 'engine', Values: [DocDBEngine] }],
+                DBClusterIdentifier: clusterId,
             }
             const command = new DocDB.DescribeDBClustersCommand(input)
             const response = await client.send(command)
@@ -158,6 +159,21 @@ export class DefaultDocumentDBClient {
             return response.DBCluster
         } catch (e) {
             throw ToolkitError.chain(e, 'Failed to create DocumentDB cluster')
+        } finally {
+            client.destroy()
+        }
+    }
+
+    public async deleteCluster(input: DocDB.DeleteDBClusterMessage): Promise<DocDB.DBCluster | undefined> {
+        getLogger().debug('DeleteCluster called')
+        const client = await this.getClient()
+
+        try {
+            const command = new DocDB.DeleteDBClusterCommand(input)
+            const response = await client.send(command)
+            return response.DBCluster
+        } catch (e) {
+            throw ToolkitError.chain(e, 'Failed to delete DocumentDB cluster')
         } finally {
             client.destroy()
         }

--- a/packages/core/src/test/docdb/commands/deleteCluster.test.ts
+++ b/packages/core/src/test/docdb/commands/deleteCluster.test.ts
@@ -1,0 +1,128 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import * as sinon from 'sinon'
+import * as vscode from 'vscode'
+import { getTestWindow } from '../../shared/vscode/window'
+import { DocumentDBClient } from '../../../shared/clients/docdbClient'
+import { DBClusterNode } from '../../../docdb/explorer/dbClusterNode'
+import { DBCluster, DBInstance } from '@aws-sdk/client-docdb'
+import { deleteCluster } from '../../../docdb/commands/deleteCluster'
+import { DocumentDBNode } from '../../../docdb/explorer/docdbNode'
+
+describe('deleteClusterCommand', function () {
+    const clusterName = 'test-cluster'
+    let docdb: DocumentDBClient
+    let cluster: DBCluster
+    let instances: DBInstance[]
+    let node: DBClusterNode
+    let sandbox: sinon.SinonSandbox
+    let spyExecuteCommand: sinon.SinonSpy
+    let deleteInstanceStub: sinon.SinonStub
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+        spyExecuteCommand = sandbox.spy(vscode.commands, 'executeCommand')
+
+        cluster = { DBClusterIdentifier: clusterName, Status: 'available' }
+        instances = [
+            { DBClusterIdentifier: clusterName, DBInstanceIdentifier: 'instance-1' },
+            { DBClusterIdentifier: clusterName, DBInstanceIdentifier: 'instance-2' },
+        ]
+
+        docdb = { regionCode: 'us-east-1' } as DocumentDBClient
+        docdb.listClusters = sinon.stub().resolves([cluster])
+        docdb.listInstances = sinon.stub().resolves(instances)
+        deleteInstanceStub = sinon.stub().onFirstCall().resolves(instances[0]).onSecondCall().resolves(instances[1])
+        docdb.deleteInstance = deleteInstanceStub
+
+        node = new DBClusterNode({} as DocumentDBNode, cluster, docdb)
+        node.waitUntilStatusChanged = sinon.stub().resolves(true)
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+        getTestWindow().dispose()
+    })
+
+    function setupWizard() {
+        getTestWindow().onDidShowInputBox(input => {
+            input.acceptValue(input.placeholder!)
+        })
+
+        getTestWindow().onDidShowQuickPick(async picker => {
+            await picker.untilReady()
+            picker.acceptItem(picker.items[0])
+        })
+    }
+
+    it('prompts for snapshot and confirmation, deletes all instances, deletes cluster, and refreshes node', async function () {
+        // arrange
+        const deleteClusterStub = sinon.stub().resolves({
+            DBClusterIdentifier: clusterName,
+            Status: 'backing up',
+        })
+        docdb.deleteCluster = deleteClusterStub
+        setupWizard()
+
+        // act
+        await deleteCluster(node)
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertInfo(/Deleting cluster: test-cluster/)
+
+        assert(deleteClusterStub.calledOnceWithExactly(sinon.match({ DBClusterIdentifier: clusterName })))
+        assert(deleteInstanceStub.calledTwice)
+        sandbox.assert.calledWith(spyExecuteCommand, 'aws.refreshAwsExplorerNode', node)
+    })
+
+    it('does nothing when prompt is cancelled', async function () {
+        // arrange
+        const deleteClusterStub = sinon.stub()
+        docdb.deleteCluster = deleteClusterStub
+        getTestWindow().onDidShowQuickPick(picker => picker.hide())
+        getTestWindow().onDidShowInputBox(input => input.hide())
+
+        // act
+        await deleteCluster(node)
+
+        // assert
+        assert(deleteClusterStub.notCalled)
+    })
+
+    it('shows a warning when the cluster is stopped', async function () {
+        // arrange
+        cluster.Status = 'stopped'
+        const deleteClusterStub = sinon.stub()
+        docdb.deleteCluster = deleteClusterStub
+        setupWizard()
+
+        // act
+        await deleteCluster(node)
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertMessage(/Cluster must be running/)
+    })
+
+    it('shows an error when cluster deletion fails', async function () {
+        // arrange
+        const deleteClusterStub = sinon.stub().rejects()
+        docdb.deleteCluster = deleteClusterStub
+        setupWizard()
+
+        // act
+        await deleteCluster(node)
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertError(/Failed to delete cluster: test-cluster/)
+    })
+})


### PR DESCRIPTION
- Allow instances to be deleted regardless of deletion protection flag
- Release sdk client resources
- Register aws.docdb.deleteCluster menu command
- Prompt for confirmation before deleting
- Delete cluster along with all instances
- Wait for status change before refresh