### PR TITLE
AD-1113: Update instance placeholder to add new instance

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2018,7 +2018,7 @@
                 },
                 {
                     "command": "aws.docdb.createInstance",
-                    "when": "viewItem == awsDocDB.cluster.running"
+                    "when": "viewItem =~ /^awsDocDB.cluster/"
                 },
                 {
                     "command": "aws.docdb.renameInstance",
@@ -3590,7 +3590,7 @@
                 "title": "%AWS.command.docdb.createInstance%",
                 "icon": "$(add)",
                 "category": "%AWS.title%",
-                "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB.cluster/",
+                "enablement": "(isCloud9 || !aws.isWebExtHost)",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"

--- a/packages/core/src/docdb/explorer/dbClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbClusterNode.ts
@@ -44,17 +44,22 @@ export class DBClusterNode extends AWSTreeNodeBase implements AWSResourceNode {
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
-                const instances: DBInstance[] = (await this.client.listInstances([this.arn])).map(i => {
+                const instances: DBInstance[] = (await this.client.listInstances([this.arn])).map((i) => {
                     const member = this.cluster.DBClusterMembers?.find(
-                        m => m.DBInstanceIdentifier === i.DBInstanceIdentifier
+                        (m) => m.DBInstanceIdentifier === i.DBInstanceIdentifier
                     )
                     return { ...i, ...member }
                 })
-                const nodes = instances.map(instance => new DBInstanceNode(this, instance))
+                const nodes = instances.map((instance) => new DBInstanceNode(this, instance))
                 return nodes
             },
-            getNoChildrenPlaceholderNode: async () =>
-                new PlaceholderNode(this, localize('AWS.explorerNode.docdb.noInstances', '[No Instances found]')),
+            getNoChildrenPlaceholderNode: async () => {
+                const title = localize('AWS.explorerNode.docdb.addInstance', 'Add instance...')
+                const placeholder = new PlaceholderNode(this, title)
+                placeholder.contextValue = 'awsDocDB.placeholder'
+                placeholder.command = { title, command: 'aws.docdb.createInstance', arguments: [this] }
+                return placeholder
+            },
             sort: (item1, item2) => item1.name.localeCompare(item2.name),
         })
     }


### PR DESCRIPTION
## Problem

Not obvious to user how to add an instance to an empty cluster

## Solution

Update the placeholder from '[No instances found]' to 'Add instance...' 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
