### PR TITLE
AD-1114: Create instances when creating regional cluster

### DIFF
--- a/packages/core/src/docdb/commands/createCluster.ts
+++ b/packages/core/src/docdb/commands/createCluster.ts
@@ -34,6 +34,18 @@ export async function createCluster(node?: DocumentDBNode) {
     try {
         const cluster = await node?.createCluster(result)
 
+        // create instances for cluster
+        if (cluster && result.DBInstanceCount) {
+            for (let index = 0; index < result.DBInstanceCount; index++) {
+                await node?.client.createInstance({
+                    Engine: 'docdb',
+                    DBClusterIdentifier: clusterName,
+                    DBInstanceIdentifier: index === 0 ? clusterName : `${clusterName}${index + 1}`,
+                    DBInstanceClass: result.DBInstanceClass ?? 'db.t3.medium',
+                })
+            }
+        }
+
         getLogger().info('Created cluster: %O', cluster)
         void vscode.window.showInformationMessage(
             localize('AWS.docdb.createCluster.success', 'Created cluster: {0}', clusterName)

--- a/packages/core/src/docdb/commands/createInstance.ts
+++ b/packages/core/src/docdb/commands/createInstance.ts
@@ -34,12 +34,6 @@ export async function createInstance(node: DBClusterNode) {
         )
         return
     }
-    if (node.status !== 'available') {
-        void vscode.window.showInformationMessage(
-            localize('AWS.docdb.createInstance.clusterStopped', 'Cluster must be started to create instances')
-        )
-        return
-    }
 
     const generateInstanceName = (clusterName: string) =>
         instances.length === 0 ? clusterName : `${clusterName}${++instances.length}`

--- a/packages/core/src/docdb/commands/deleteCluster.ts
+++ b/packages/core/src/docdb/commands/deleteCluster.ts
@@ -75,13 +75,13 @@ export async function deleteCluster(node: DBClusterNode) {
 
         const cluster = await node.deleteCluster(finalSnapshotId)
 
-        getLogger().info('Deleted cluster: %O', cluster)
         void vscode.window.showInformationMessage(
             localize('AWS.docdb.deleteCluster.success', 'Deleting cluster: {0}', clusterName)
         )
 
         await node.waitUntilStatusChanged()
-        node.refresh()
+        node.parent.refresh()
+        getLogger().info('Deleted cluster: %O', cluster)
         return cluster
     } catch (e) {
         getLogger().error(`Failed to delete cluster ${clusterName}: %s`, e)
@@ -97,7 +97,7 @@ async function showConfirmationDialog(): Promise<boolean> {
     const confirmationInput = await vscode.window.showInputBox({
         prompt,
         placeHolder: confirmValue,
-        validateInput: input => (input?.toLowerCase() !== confirmValue ? prompt : undefined),
+        validateInput: (input) => (input?.toLowerCase() !== confirmValue ? prompt : undefined),
     })
 
     return confirmationInput === confirmValue

--- a/packages/core/src/docdb/explorer/dbClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbClusterNode.ts
@@ -87,11 +87,15 @@ export class DBClusterNode extends AWSTreeNodeBase implements AWSResourceNode {
     public async deleteCluster(finalSnapshotId: string | undefined): Promise<DBCluster | undefined> {
         const instances = await this.client.listInstances([this.arn])
 
+        const tasks = []
         for (const instance of instances) {
-            await this.client.deleteInstance({
-                DBInstanceIdentifier: instance.DBInstanceIdentifier,
-            })
+            tasks.push(
+                this.client.deleteInstance({
+                    DBInstanceIdentifier: instance.DBInstanceIdentifier,
+                })
+            )
         }
+        await Promise.all(tasks)
 
         return await this.client.deleteCluster({
             DBClusterIdentifier: this.cluster.DBClusterIdentifier,

--- a/packages/core/src/docdb/wizards/createClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/createClusterWizard.ts
@@ -182,16 +182,17 @@ async function createInstanceClassPrompter(docdbClient: DocumentDBClient, engine
 }
 
 function instanceCountItems(max: number = 16): DataQuickPickItem<number>[] {
+    const defaultCount = Math.min(3, max)
     const items = []
 
     for (let index = 1; index <= max; index++) {
         const item: DataQuickPickItem<number> = {
             label: index.toString(),
             data: index,
+            description: index === defaultCount ? '(recommended)' : undefined,
         }
         items.push(item)
     }
 
-    items[2].description = '(recommended)'
     return items
 }

--- a/packages/core/src/test/docdb/commands/createInstance.test.ts
+++ b/packages/core/src/test/docdb/commands/createInstance.test.ts
@@ -43,11 +43,11 @@ describe('createInstanceCommand', function () {
     })
 
     function setupWizard() {
-        getTestWindow().onDidShowInputBox(input => {
+        getTestWindow().onDidShowInputBox((input) => {
             input.acceptValue(instanceName)
         })
 
-        getTestWindow().onDidShowQuickPick(async picker => {
+        getTestWindow().onDidShowQuickPick(async (picker) => {
             await picker.untilReady()
             picker.acceptItem(picker.items[0])
         })
@@ -85,7 +85,7 @@ describe('createInstanceCommand', function () {
         // arrange
         const stub = sinon.stub()
         docdb.createInstance = stub
-        getTestWindow().onDidShowInputBox(input => input.hide())
+        getTestWindow().onDidShowInputBox((input) => input.hide())
 
         // act
         await createInstance(node)
@@ -108,22 +108,6 @@ describe('createInstanceCommand', function () {
         getTestWindow()
             .getFirstMessage()
             .assertMessage(/Max instances in use/)
-    })
-
-    it('shows a warning when the cluster is stopped', async function () {
-        // arrange
-        cluster.Status = 'stopped'
-        const stub = sinon.stub()
-        docdb.createInstance = stub
-        setupWizard()
-
-        // act
-        await createInstance(node)
-
-        // assert
-        getTestWindow()
-            .getFirstMessage()
-            .assertMessage(/Cluster must be started to create instances/)
     })
 
     it('shows an error when instance creation fails', async function () {

--- a/packages/core/src/test/docdb/commands/deleteCluster.test.ts
+++ b/packages/core/src/test/docdb/commands/deleteCluster.test.ts
@@ -39,7 +39,8 @@ describe('deleteClusterCommand', function () {
         deleteInstanceStub = sinon.stub().onFirstCall().resolves(instances[0]).onSecondCall().resolves(instances[1])
         docdb.deleteInstance = deleteInstanceStub
 
-        node = new DBClusterNode({} as DocumentDBNode, cluster, docdb)
+        const parentNode = new DocumentDBNode(docdb)
+        node = new DBClusterNode(parentNode, cluster, docdb)
         node.waitUntilStatusChanged = sinon.stub().resolves(true)
     })
 
@@ -49,11 +50,11 @@ describe('deleteClusterCommand', function () {
     })
 
     function setupWizard() {
-        getTestWindow().onDidShowInputBox(input => {
+        getTestWindow().onDidShowInputBox((input) => {
             input.acceptValue(input.placeholder!)
         })
 
-        getTestWindow().onDidShowQuickPick(async picker => {
+        getTestWindow().onDidShowQuickPick(async (picker) => {
             await picker.untilReady()
             picker.acceptItem(picker.items[0])
         })
@@ -78,15 +79,15 @@ describe('deleteClusterCommand', function () {
 
         assert(deleteClusterStub.calledOnceWithExactly(sinon.match({ DBClusterIdentifier: clusterName })))
         assert(deleteInstanceStub.calledTwice)
-        sandbox.assert.calledWith(spyExecuteCommand, 'aws.refreshAwsExplorerNode', node)
+        sandbox.assert.calledWith(spyExecuteCommand, 'aws.refreshAwsExplorerNode', node.parent)
     })
 
     it('does nothing when prompt is cancelled', async function () {
         // arrange
         const deleteClusterStub = sinon.stub()
         docdb.deleteCluster = deleteClusterStub
-        getTestWindow().onDidShowQuickPick(picker => picker.hide())
-        getTestWindow().onDidShowInputBox(input => input.hide())
+        getTestWindow().onDidShowQuickPick((picker) => picker.hide())
+        getTestWindow().onDidShowInputBox((input) => input.hide())
 
         // act
         await deleteCluster(node)

--- a/packages/core/src/test/shared/clients/defaultDocdbClient.test.ts
+++ b/packages/core/src/test/shared/clients/defaultDocdbClient.test.ts
@@ -18,6 +18,7 @@ describe('DefaultDocumentDBClient', function () {
                 DBClusters: [],
                 DBInstances: [],
             }),
+            destroy: sinon.stub(),
         })
     })
 


### PR DESCRIPTION
## Problem

Desired behavior is to create cluster with instances like the AWS console does.

## Solution

Create cluster now prompts for number of instances and instance class

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
