### PR TITLE
AD-1108: Add support for tags on clusters and instances

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2045,6 +2045,10 @@
                     "command": "aws.docdb.deleteInstance",
                     "when": "viewItem == awsDocDB.instance.available",
                     "group": "0@2"
+                },
+                {
+                    "command": "aws.docdb.listTags",
+                    "when": "viewItem =~ /^awsDocDB\\./"
                 }
             ],
             "aws.toolkit.auth": [
@@ -3688,6 +3692,17 @@
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
                 "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB.cluster.running/",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.docdb.listTags",
+                "title": "%AWS.command.docdb.tags%",
+                "category": "%AWS.title%",
+                "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB/",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -272,5 +272,6 @@
     "AWS.command.docdb.modifyInstance": "Modify Class...",
     "AWS.command.docdb.rebootInstance": "Reboot Instance",
     "AWS.command.docdb.startCluster": "Start Cluster",
-    "AWS.command.docdb.stopCluster": "Stop Cluster"
+    "AWS.command.docdb.stopCluster": "Stop Cluster",
+    "AWS.command.docdb.tags": "Tags..."
 }

--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -5,7 +5,7 @@
 
 import { Commands } from '../shared'
 import { ExtContext } from '../shared/extensions'
-import { DBNode, DocumentDBNode } from './explorer/docdbNode'
+import { DocumentDBNode } from './explorer/docdbNode'
 import { DBClusterNode } from './explorer/dbClusterNode'
 import { DBInstanceNode } from './explorer/dbInstanceNode'
 import { createCluster } from './commands/createCluster'
@@ -32,11 +32,11 @@ export async function activate(ctx: ExtContext): Promise<void> {
             await renameCluster(node)
         }),
 
-        Commands.register('aws.docdb.startCluster', async (node?: DBNode) => {
+        Commands.register('aws.docdb.startCluster', async (node?: DBClusterNode) => {
             await startCluster(node)
         }),
 
-        Commands.register('aws.docdb.stopCluster', async (node?: DBNode) => {
+        Commands.register('aws.docdb.stopCluster', async (node?: DBClusterNode) => {
             await stopCluster(node)
         }),
 

--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -5,6 +5,7 @@
 
 import { Commands } from '../shared'
 import { ExtContext } from '../shared/extensions'
+import { DBResourceNode } from './explorer/dbResourceNode'
 import { DocumentDBNode } from './explorer/docdbNode'
 import { DBClusterNode } from './explorer/dbClusterNode'
 import { DBInstanceNode } from './explorer/dbInstanceNode'
@@ -16,8 +17,8 @@ import { renameCluster } from './commands/renameCluster'
 import { renameInstance } from './commands/renameInstance'
 import { modifyInstance } from './commands/modifyInstance'
 import { rebootInstance } from './commands/rebootInstance'
-import { listTags, startCluster, stopCluster } from './commands/commands'
-import { DBResourceNode } from './explorer/dbResourceNode'
+import { startCluster, stopCluster } from './commands/commands'
+import { addTag, listTags, removeTag } from './commands/tagCommands'
 
 /**
  * Activates DocumentDB components.
@@ -67,6 +68,14 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
         Commands.register('aws.docdb.listTags', async (node: DBResourceNode) => {
             await listTags(node)
+        }),
+
+        Commands.register('aws.docdb.addTag', async (node: DBResourceNode) => {
+            await addTag(node)
+        }),
+
+        Commands.register('aws.docdb.removeTag', async (node: DBResourceNode) => {
+            await removeTag(node)
         })
     )
 }

--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -16,7 +16,8 @@ import { renameCluster } from './commands/renameCluster'
 import { renameInstance } from './commands/renameInstance'
 import { modifyInstance } from './commands/modifyInstance'
 import { rebootInstance } from './commands/rebootInstance'
-import { startCluster, stopCluster } from './commands/commands'
+import { listTags, startCluster, stopCluster } from './commands/commands'
+import { DBResourceNode } from './explorer/dbResourceNode'
 
 /**
  * Activates DocumentDB components.
@@ -62,6 +63,10 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
         Commands.register('aws.docdb.rebootInstance', async (node: DBInstanceNode) => {
             await rebootInstance(node)
+        }),
+
+        Commands.register('aws.docdb.listTags', async (node: DBResourceNode) => {
+            await listTags(node)
         })
     )
 }

--- a/packages/core/src/docdb/commands/commands.ts
+++ b/packages/core/src/docdb/commands/commands.ts
@@ -8,7 +8,6 @@ import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { DBClusterNode } from '../explorer/dbClusterNode'
-import { DBResourceNode } from '../explorer/dbResourceNode'
 
 export function startCluster(node?: DBClusterNode): Promise<void> {
     return telemetry.docdb_startCluster.run(async () => {
@@ -34,10 +33,4 @@ export function stopCluster(node?: DBClusterNode): Promise<void> {
             node?.parent.refresh()
         }
     })
-}
-
-export async function listTags(node: DBResourceNode): Promise<void> {
-    const tags = await node.listTags()
-    const detail = tags.length ? tags.map((tag) => `${tag.Key} = ${tag.Value}`).join('\n') : '[No tags assigned]'
-    void vscode.window.showInformationMessage(`Tags for: ${node.name}`, { modal: true, detail })
 }

--- a/packages/core/src/docdb/commands/commands.ts
+++ b/packages/core/src/docdb/commands/commands.ts
@@ -8,6 +8,7 @@ import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { DBClusterNode } from '../explorer/dbClusterNode'
+import { DBResourceNode } from '../explorer/dbResourceNode'
 
 export function startCluster(node?: DBClusterNode): Promise<void> {
     return telemetry.docdb_startCluster.run(async () => {
@@ -33,4 +34,10 @@ export function stopCluster(node?: DBClusterNode): Promise<void> {
             node?.parent.refresh()
         }
     })
+}
+
+export async function listTags(node: DBResourceNode): Promise<void> {
+    const tags = await node.listTags()
+    const detail = tags.length ? tags.map((tag) => `${tag.Key} = ${tag.Value}`).join('\n') : '[No tags assigned]'
+    void vscode.window.showInformationMessage(`Tags for: ${node.name}`, { modal: true, detail })
 }

--- a/packages/core/src/docdb/commands/commands.ts
+++ b/packages/core/src/docdb/commands/commands.ts
@@ -7,31 +7,28 @@ import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { DBNode } from '../explorer/docdbNode'
-import { DefaultDocumentDBClient } from '../../shared/clients/docdbClient'
+import { DBClusterNode } from '../explorer/dbClusterNode'
 
-export function startCluster(node?: DBNode): Promise<void> {
+export function startCluster(node?: DBClusterNode): Promise<void> {
     return telemetry.docdb_startCluster.run(async () => {
-        if (node?.id && node?.regionCode) {
-            const client = new DefaultDocumentDBClient(node.regionCode)
-            await client.startCluster(node.id)
-            getLogger().info('Start cluster: %O', node.id)
+        if (node?.arn && node?.regionCode) {
+            await node.client.startCluster(node.arn)
+            getLogger().info('Start cluster: %O', node.name)
             void vscode.window.showInformationMessage(
-                localize('AWS.docdb.startCluster.success', 'Starting cluster: {0}', node.id)
+                localize('AWS.docdb.startCluster.success', 'Starting cluster: {0}', node.name)
             )
             node?.parent.refresh()
         }
     })
 }
 
-export function stopCluster(node?: DBNode): Promise<void> {
+export function stopCluster(node?: DBClusterNode): Promise<void> {
     return telemetry.docdb_stopCluster.run(async () => {
-        if (node?.id && node?.regionCode) {
-            const client = new DefaultDocumentDBClient(node.regionCode)
-            await client.stopCluster(node.id)
-            getLogger().info('Stop cluster: %O', node.id)
+        if (node?.arn && node?.regionCode) {
+            await node.client.stopCluster(node.arn)
+            getLogger().info('Stop cluster: %O', node.name)
             void vscode.window.showInformationMessage(
-                localize('AWS.docdb.stopCluster.success', 'Stopping cluster: {0}', node.id)
+                localize('AWS.docdb.stopCluster.success', 'Stopping cluster: {0}', node.name)
             )
             node?.parent.refresh()
         }

--- a/packages/core/src/docdb/commands/tagCommands.ts
+++ b/packages/core/src/docdb/commands/tagCommands.ts
@@ -1,0 +1,95 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from '../../shared/logger'
+import { telemetry } from '../../shared/telemetry'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { DBResourceNode } from '../explorer/dbResourceNode'
+import { DataQuickPickItem, showQuickPick } from '../../shared/ui/pickerPrompter'
+import { ToolkitError } from '../../shared'
+
+export async function listTags(node: DBResourceNode): Promise<void> {
+    return telemetry.docdb_listTags.run(async () => {
+        const tags = await node.listTags()
+        const detail = tags.length
+            ? tags.map((tag) => `• ${tag.Key} = ${tag.Value}`).join('\r\n')
+            : '[No tags assigned]'
+
+        const addCommandText = localize('AWS.docdb.tags.add', 'Add tag...')
+        const removeCommandText = tags.length ? localize('AWS.docdb.tags.remove', 'Remove...') : ''
+        const commands = tags.length ? [addCommandText, removeCommandText] : [addCommandText]
+
+        const response = await vscode.window.showInformationMessage(
+            `Tags for ${node.name}:`,
+            { modal: true, detail },
+            ...commands
+        )
+
+        switch (response) {
+            case addCommandText:
+                await addTag(node)
+                break
+            case removeCommandText:
+                await removeTag(node)
+                break
+        }
+    })
+}
+
+export async function addTag(node: DBResourceNode): Promise<void> {
+    return telemetry.docdb_addTag.run(async () => {
+        const Key = await vscode.window.showInputBox({
+            title: 'Add Tag',
+            prompt: localize('AWS.docdb.tags.add.keyPrompt', 'Enter a key for the new tag'),
+        })
+        if (Key === undefined) {
+            getLogger().info('AddTag cancelled')
+            throw new ToolkitError('User cancelled', { cancelled: true })
+        }
+
+        const Value = await vscode.window.showInputBox({
+            title: 'Add Tag',
+            prompt: localize('AWS.docdb.tags.add.valuePrompt', 'Enter the value for the new tag'),
+        })
+        if (Value === undefined) {
+            getLogger().info('AddTag cancelled')
+            throw new ToolkitError('User cancelled', { cancelled: true })
+        }
+
+        await node.client.addResourceTags({ ResourceName: node.arn, Tags: [{ Key, Value }] })
+        getLogger().info('Added resource tag for: %O', node.name)
+        void vscode.window.showInformationMessage(localize('AWS.docdb.tags.add.success', 'Tag added'))
+    })
+}
+
+export async function removeTag(node: DBResourceNode): Promise<void> {
+    return telemetry.docdb_removeTag.run(async () => {
+        const tags = await node.listTags()
+        const items = tags.map<DataQuickPickItem<string>>((tag) => {
+            return {
+                data: tag.Key,
+                label: tag.Key!,
+                description: tag.Value,
+            }
+        })
+        if (items.length === 0) {
+            return
+        }
+
+        const resp = await showQuickPick(items, {
+            title: localize('AWS.docdb.tags.remove.title', 'Remove a tag from {0}', node.name),
+        })
+
+        if (resp === undefined) {
+            getLogger().info('RemoveTag cancelled')
+            throw new ToolkitError('User cancelled', { cancelled: true })
+        }
+
+        await node.client.removeResourceTags({ ResourceName: node.arn, TagKeys: [resp] })
+        getLogger().info('Removed resource tag for: %O', node.name)
+        void vscode.window.showInformationMessage(localize('AWS.docdb.tags.remove.success', 'Tag removed'))
+    })
+}

--- a/packages/core/src/docdb/explorer/dbClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbClusterNode.ts
@@ -11,7 +11,7 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 import { waitUntil } from '../../shared'
 import { CreateDBInstanceMessage, DBCluster, ModifyDBClusterMessage } from '@aws-sdk/client-docdb'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
-import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
+import { DBResourceNode } from './dbResourceNode'
 import { DBInstanceNode } from './dbInstanceNode'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { DBInstance, DocumentDBClient } from '../../shared/clients/docdbClient'
@@ -23,19 +23,19 @@ import { telemetry } from '../../shared/telemetry'
  *
  * Contains instances for a specific cluster as child nodes.
  */
-export class DBClusterNode extends AWSTreeNodeBase implements AWSResourceNode {
-    public override readonly regionCode: string
-    name: string = this.cluster.DBClusterIdentifier ?? ''
-    arn: string = this.cluster.DBClusterArn ?? ''
+export class DBClusterNode extends DBResourceNode {
+    override name = this.cluster.DBClusterIdentifier!
+    override arn = this.cluster.DBClusterArn!
 
     constructor(
         public readonly parent: AWSTreeNodeBase,
         readonly cluster: DBCluster,
-        readonly client: DocumentDBClient
+        client: DocumentDBClient
     ) {
-        super(cluster.DBClusterIdentifier ?? '[Cluster]', vscode.TreeItemCollapsibleState.Collapsed)
+        super(client, cluster.DBClusterIdentifier ?? '[Cluster]', vscode.TreeItemCollapsibleState.Collapsed)
         this.id = cluster.DBClusterIdentifier
-        this.regionCode = client.regionCode
+        this.arn = cluster.DBClusterArn ?? ''
+        this.name = cluster.DBClusterIdentifier ?? ''
         this.contextValue = this.getContext()
         this.iconPath = undefined //TODO: determine icon for regional cluster
         this.description = this.getDescription()

--- a/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
@@ -6,26 +6,24 @@
 import * as vscode from 'vscode'
 import { inspect } from 'util'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
-import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
+import { DBResourceNode } from './dbResourceNode'
 import { DBElasticCluster, DocumentDBClient } from '../../shared/clients/docdbClient'
 import { DocDBContext, DocDBNodeContext } from './docdbContext'
 
 /**
  * An AWS Explorer node representing DocumentDB elastic clusters.
  */
-export class DBElasticClusterNode extends AWSTreeNodeBase implements AWSResourceNode {
-    public override readonly regionCode: string
-    name: string = this.cluster.clusterName ?? ''
-    arn: string = this.cluster.clusterArn ?? ''
+export class DBElasticClusterNode extends DBResourceNode {
+    override name = this.cluster.clusterName!
+    override arn = this.cluster.clusterArn!
 
     constructor(
         public readonly parent: AWSTreeNodeBase,
         readonly cluster: DBElasticCluster,
-        readonly client: DocumentDBClient
+        client: DocumentDBClient
     ) {
-        super(cluster.clusterName ?? '[Cluster]', vscode.TreeItemCollapsibleState.None)
+        super(client, cluster.clusterName ?? '[Cluster]', vscode.TreeItemCollapsibleState.None)
         this.id = cluster.clusterArn
-        this.regionCode = client.regionCode
         this.contextValue = this.getContext()
         this.iconPath = new vscode.ThemeIcon('layers-dot') //TODO: determine icon for elastic cluster
         this.description = this.getDescription()

--- a/packages/core/src/docdb/explorer/dbInstanceNode.ts
+++ b/packages/core/src/docdb/explorer/dbInstanceNode.ts
@@ -5,9 +5,9 @@
 
 import * as vscode from 'vscode'
 import { inspect } from 'util'
-import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { DBInstance } from '../../shared/clients/docdbClient'
 import { DocDBContext, DocDBNodeContext } from './docdbContext'
+import { DBResourceNode } from './dbResourceNode'
 import { DBClusterNode } from './dbClusterNode'
 import { ModifyDBInstanceMessage } from '@aws-sdk/client-docdb'
 import { waitUntil } from '../../shared'
@@ -15,14 +15,15 @@ import { waitUntil } from '../../shared'
 /**
  * An AWS Explorer node representing a DocumentDB instance.
  */
-export class DBInstanceNode extends AWSTreeNodeBase {
-    public name: string = this.instance.DBInstanceIdentifier ?? ''
+export class DBInstanceNode extends DBResourceNode {
+    override name = this.instance.DBInstanceIdentifier!
+    override arn = this.instance.DBInstanceArn!
 
     constructor(
         public readonly parent: DBClusterNode,
         readonly instance: DBInstance
     ) {
-        super(instance.DBInstanceIdentifier ?? '[Instance]', vscode.TreeItemCollapsibleState.None)
+        super(parent.client, instance.DBInstanceIdentifier ?? '[Instance]', vscode.TreeItemCollapsibleState.None)
         this.id = instance.DBInstanceArn
         this.description = this.makeDescription()
         this.contextValue = this.getContext()

--- a/packages/core/src/docdb/explorer/dbResourceNode.ts
+++ b/packages/core/src/docdb/explorer/dbResourceNode.ts
@@ -8,6 +8,7 @@ import { inspect } from 'util'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { DocumentDBClient } from '../../shared/clients/docdbClient'
+import { Tag } from '@aws-sdk/client-docdb'
 
 /** An AWS Explorer node representing a DocumentDB resource. */
 export abstract class DBResourceNode extends AWSTreeNodeBase implements AWSResourceNode {
@@ -26,5 +27,9 @@ export abstract class DBResourceNode extends AWSTreeNodeBase implements AWSResou
 
     public [inspect.custom](): string {
         return 'DBResourceNode'
+    }
+
+    public async listTags(): Promise<Tag[]> {
+        return await this.client.listResourceTags(this.arn)
     }
 }

--- a/packages/core/src/docdb/explorer/dbResourceNode.ts
+++ b/packages/core/src/docdb/explorer/dbResourceNode.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { inspect } from 'util'
+import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
+import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
+import { DocumentDBClient } from '../../shared/clients/docdbClient'
+
+/** An AWS Explorer node representing a DocumentDB resource. */
+export abstract class DBResourceNode extends AWSTreeNodeBase implements AWSResourceNode {
+    public override readonly regionCode: string
+    public abstract readonly arn: string
+    public abstract readonly name: string
+
+    protected constructor(
+        public readonly client: DocumentDBClient,
+        label: string,
+        collapsibleState?: vscode.TreeItemCollapsibleState
+    ) {
+        super(label, collapsibleState)
+        this.regionCode = client.regionCode
+    }
+
+    public [inspect.custom](): string {
+        return 'DBResourceNode'
+    }
+}

--- a/packages/core/src/docdb/explorer/docdbNode.ts
+++ b/packages/core/src/docdb/explorer/docdbNode.ts
@@ -12,11 +12,8 @@ import { makeChildrenNodes } from '../../shared/treeview/utils'
 import { DocumentDBClient } from '../../shared/clients/docdbClient'
 import { DBClusterNode } from './dbClusterNode'
 import { DBElasticClusterNode } from './dbElasticClusterNode'
-import { DBInstanceNode } from './dbInstanceNode'
 import { CreateDBClusterMessage, DBCluster } from '@aws-sdk/client-docdb'
 import { telemetry } from '../../shared/telemetry'
-
-export type DBNode = DBClusterNode | DBElasticClusterNode | DBInstanceNode
 
 /**
  * An AWS Explorer node representing DocumentDB.

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -302,4 +302,19 @@ export class DefaultDocumentDBClient {
             client.destroy()
         }
     }
+
+    public async listResourceTags(arn: string): Promise<DocDB.Tag[]> {
+        getLogger().debug('ListResourceTags called')
+        const client = await this.getClient()
+
+        try {
+            const command = new DocDB.ListTagsForResourceCommand({ ResourceName: arn })
+            const response = await client.send(command)
+            return response.TagList ?? []
+        } catch (e) {
+            throw ToolkitError.chain(e, 'Failed to get resource tags')
+        } finally {
+            client.destroy()
+        }
+    }
 }

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -317,4 +317,32 @@ export class DefaultDocumentDBClient {
             client.destroy()
         }
     }
+
+    public async addResourceTags(input: DocDB.AddTagsToResourceCommandInput): Promise<void> {
+        getLogger().debug('AddResourceTags called')
+        const client = await this.getClient()
+
+        try {
+            const command = new DocDB.AddTagsToResourceCommand(input)
+            await client.send(command)
+        } catch (e) {
+            throw ToolkitError.chain(e, 'Failed to add resource tags')
+        } finally {
+            client.destroy()
+        }
+    }
+
+    public async removeResourceTags(input: DocDB.RemoveTagsFromResourceCommandInput): Promise<void> {
+        getLogger().debug('RemoveResourceTags called')
+        const client = await this.getClient()
+
+        try {
+            const command = new DocDB.RemoveTagsFromResourceCommand(input)
+            await client.send(command)
+        } catch (e) {
+            throw ToolkitError.chain(e, 'Failed to remove resource tags')
+        } finally {
+            client.destroy()
+        }
+    }
 }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1431,6 +1431,18 @@
         {
             "name": "docdb_startCluster",
             "description": "Captures the result of starting a cluster"
+        },
+        {
+            "name": "docdb_listTags",
+            "description": "User clicked on tags command"
+        },
+        {
+            "name": "docdb_addTag",
+            "description": "User clicked on add tag command"
+        },
+        {
+            "name": "docdb_removeTag",
+            "description": "User clicked on remove tag command"
         }
     ]
 }

--- a/packages/core/src/test/docdb/commands/tagCommands.test.ts
+++ b/packages/core/src/test/docdb/commands/tagCommands.test.ts
@@ -1,0 +1,166 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import * as sinon from 'sinon'
+import { assertTelemetry } from '../../testUtil'
+import { getTestWindow } from '../../shared/vscode/window'
+import { DocumentDBClient, DBInstance } from '../../../shared/clients/docdbClient'
+import { DBClusterNode } from '../../../docdb/explorer/dbClusterNode'
+import { DBInstanceNode } from '../../../docdb/explorer/dbInstanceNode'
+import { DocumentDBNode } from '../../../docdb/explorer/docdbNode'
+import { addTag, listTags, removeTag } from '../../../docdb/commands/tagCommands'
+
+describe('Tags', function () {
+    const instanceName = 'test-instance'
+    let docdb: DocumentDBClient
+    let instance: DBInstance
+    let node: DBInstanceNode
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+
+        docdb = { regionCode: 'us-east-1' } as DocumentDBClient
+        const clusterName = 'docdb-1234'
+        const cluster = { DBClusterIdentifier: clusterName, Status: 'available' }
+        const parentNode = new DBClusterNode(new DocumentDBNode(docdb), cluster, docdb)
+        instance = {
+            DBInstanceIdentifier: instanceName,
+            DBInstanceArn: 'arn:' + instanceName,
+            DBClusterIdentifier: clusterName,
+        }
+        node = new DBInstanceNode(parentNode, instance)
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+        getTestWindow().dispose()
+    })
+
+    describe('listTagsCommand', function () {
+        it('displays a list of resource tags', async function () {
+            // arrange
+            const stub = sinon.stub().resolves([])
+            docdb.listResourceTags = stub
+            getTestWindow().onDidShowMessage((message) => {
+                assert.equal(message.message, 'Tags for test-instance:')
+                message.close()
+            })
+
+            // act
+            await listTags(node)
+
+            // assert
+            assert(stub.calledOnceWithExactly(node.arn))
+            assertTelemetry('docdb_listTags', { result: 'Succeeded' })
+        })
+
+        it('shows an error when api returns failure', async function () {
+            // arrange
+            const stub = sinon.stub().rejects()
+            docdb.listResourceTags = stub
+
+            // act
+            await assert.rejects(listTags(node))
+
+            // assert
+            assertTelemetry('docdb_listTags', { result: 'Failed' })
+        })
+    })
+
+    describe('addTagCommand', function () {
+        it('prompts for a new tag key/value and adds the tag', async function () {
+            // arrange
+            const stub = sinon.stub().resolves()
+            docdb.addResourceTags = stub
+            getTestWindow().onDidShowInputBox((input) => input.acceptValue('test-value'))
+
+            // act
+            await addTag(node)
+
+            // assert
+            assert(stub.calledOnce)
+            getTestWindow().getFirstMessage().assertInfo('Tag added')
+            assertTelemetry('docdb_addTag', { result: 'Succeeded' })
+        })
+
+        it('does nothing when prompt is cancelled', async function () {
+            // arrange
+            const stub = sinon.stub().resolves()
+            docdb.addResourceTags = stub
+            getTestWindow().onDidShowInputBox((input) => input.hide())
+
+            // act
+            await assert.rejects(addTag(node))
+
+            // assert
+            assert(stub.notCalled)
+            assertTelemetry('docdb_addTag', { result: 'Cancelled' })
+        })
+
+        it('shows an error when api returns failure', async function () {
+            // arrange
+            const stub = sinon.stub().rejects()
+            docdb.addResourceTags = stub
+            getTestWindow().onDidShowInputBox((input) => input.acceptValue('test-value'))
+
+            // act
+            await assert.rejects(addTag(node))
+
+            // assert
+            assertTelemetry('docdb_addTag', { result: 'Failed' })
+        })
+    })
+
+    describe('removeTagCommand', function () {
+        it('prompts with a list of tags and removes the selected tag', async function () {
+            // arrange
+            const tag = { Key: 'test-key', Value: 'test-value ' }
+            docdb.listResourceTags = sinon.stub().resolves([tag])
+            const stub = sinon.stub().resolves()
+            docdb.removeResourceTags = stub
+            getTestWindow().onDidShowQuickPick((picker) => picker.acceptItem(picker.items[0]))
+
+            // act
+            await removeTag(node)
+
+            // assert
+            assert(stub.calledOnce)
+            getTestWindow().getFirstMessage().assertInfo('Tag removed')
+            assertTelemetry('docdb_removeTag', { result: 'Succeeded' })
+        })
+
+        it('does nothing when prompt is cancelled', async function () {
+            // arrange
+            const tag = { Key: 'test-key', Value: 'test-value ' }
+            docdb.listResourceTags = sinon.stub().resolves([tag])
+            const stub = sinon.stub().resolves()
+            docdb.removeResourceTags = stub
+            getTestWindow().onDidShowQuickPick((picker) => picker.hide())
+
+            // act
+            await assert.rejects(removeTag(node))
+
+            // assert
+            assert(stub.notCalled)
+            assertTelemetry('docdb_removeTag', { result: 'Cancelled' })
+        })
+
+        it('shows an error when api returns failure', async function () {
+            // arrange
+            const stub = sinon.stub().rejects()
+            docdb.listResourceTags = stub
+            docdb.removeResourceTags = stub
+            getTestWindow().onDidShowQuickPick((picker) => picker.acceptItem(picker.items[0]))
+
+            // act
+            await assert.rejects(removeTag(node))
+
+            // assert
+            assertTelemetry('docdb_removeTag', { result: 'Failed' })
+        })
+    })
+})

--- a/packages/core/src/test/docdb/explorer/dbClusterNode.test.ts
+++ b/packages/core/src/test/docdb/explorer/dbClusterNode.test.ts
@@ -11,7 +11,6 @@ import { DBCluster } from '@aws-sdk/client-docdb'
 import { DBClusterNode } from '../../../docdb/explorer/dbClusterNode'
 import { DBInstanceNode } from '../../../docdb/explorer/dbInstanceNode'
 import { DBInstance, DocumentDBClient } from '../../../shared/clients/docdbClient'
-import { DocumentDBNode } from '../../../docdb/explorer/docdbNode'
 
 describe('DBClusterNode', function () {
     let mockClient: DocumentDBClient
@@ -19,7 +18,7 @@ describe('DBClusterNode', function () {
         mockClient = {} as DocumentDBClient
     })
 
-    const parentNode = {} as DocumentDBNode
+    const parentNode = {} as AWSTreeNodeBase
     const cluster: DBCluster = { DBClusterIdentifier: 'Cluster-1' }
     const instanceA: DBInstance = { DBInstanceIdentifier: 'Instance-A' }
     const instanceB: DBInstance = { DBInstanceIdentifier: 'Instance-B' }


### PR DESCRIPTION
- Create `dbResourceNode` class
- Display assigned tags for clusters and instances
- Add command to add a tag
- Add command to remove a tag
- Unit tests