### PR TITLE
AD-1119: Add aws.docdb.copyEndpoint menu command

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2056,6 +2056,11 @@
                     "command": "aws.docdb.openBrowser",
                     "when": "viewItem =~ /^awsDocDB-/",
                     "group": "0@1"
+                },
+                {
+                    "command": "aws.docdb.copyEndpoint",
+                    "when": "viewItem =~ /^awsDocDB-/",
+                    "group": "0@1"
                 }
             ],
             "aws.toolkit.auth": [
@@ -3719,6 +3724,17 @@
             {
                 "command": "aws.docdb.openBrowser",
                 "title": "%AWS.command.docdb.open%",
+                "category": "%AWS.title%",
+                "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB/",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.docdb.copyEndpoint",
+                "title": "%AWS.command.docdb.copyEndpoint%",
                 "category": "%AWS.title%",
                 "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB/",
                 "cloud9": {

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -274,5 +274,6 @@
     "AWS.command.docdb.startCluster": "Start Cluster",
     "AWS.command.docdb.stopCluster": "Stop Cluster",
     "AWS.command.docdb.tags": "Tags...",
-    "AWS.command.docdb.open": "Open in Browser"
+    "AWS.command.docdb.open": "Open in Browser",
+    "AWS.command.docdb.copyEndpoint": "Copy Endpoint..."
 }

--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -80,6 +80,10 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
         Commands.register('aws.docdb.openBrowser', async (node?: DBResourceNode) => {
             await node?.openInBrowser()
+        }),
+
+        Commands.register('aws.docdb.copyEndpoint', async (node?: DBResourceNode) => {
+            await node?.copyEndpoint()
         })
     )
 }

--- a/packages/core/src/docdb/explorer/dbClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbClusterNode.ts
@@ -6,8 +6,10 @@
 import * as os from 'os'
 import * as vscode from 'vscode'
 import { inspect } from 'util'
+import { copyToClipboard } from '../../shared/utilities/messages'
 import { makeChildrenNodes } from '../../shared/treeview/utils'
 import { localize } from '../../shared/utilities/vsCodeUtils'
+import { telemetry } from '../../shared/telemetry'
 import { waitUntil } from '../../shared'
 import { CreateDBInstanceMessage, DBCluster, ModifyDBClusterMessage } from '@aws-sdk/client-docdb'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
@@ -16,7 +18,6 @@ import { DBInstanceNode } from './dbInstanceNode'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { DBInstance, DocumentDBClient } from '../../shared/clients/docdbClient'
 import { DocDBContext, DocDBNodeContext } from './docdbContext'
-import { telemetry } from '../../shared/telemetry'
 
 /**
  * An AWS Explorer node representing DocumentDB clusters.
@@ -139,6 +140,10 @@ export class DBClusterNode extends DBResourceNode {
         return vscode.Uri.parse(
             `https://${region}.console.aws.amazon.com/docdb/home?region=${region}#cluster-details/${this.name}`
         )
+    }
+
+    override copyEndpoint() {
+        return copyToClipboard(this.cluster.Endpoint!, this.name)
     }
 
     public [inspect.custom](): string {

--- a/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
@@ -9,6 +9,7 @@ import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { DBResourceNode } from './dbResourceNode'
 import { DBElasticCluster, DocumentDBClient } from '../../shared/clients/docdbClient'
 import { DocDBContext, DocDBNodeContext } from './docdbContext'
+import { copyToClipboard } from '../../shared/utilities/messages'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { waitUntil } from '../../shared'
 
@@ -21,7 +22,7 @@ export class DBElasticClusterNode extends DBResourceNode {
 
     constructor(
         public readonly parent: AWSTreeNodeBase,
-        readonly cluster: DBElasticCluster,
+        public cluster: DBElasticCluster,
         client: DocumentDBClient
     ) {
         super(client, cluster.clusterName ?? '[Cluster]', vscode.TreeItemCollapsibleState.None)
@@ -85,6 +86,14 @@ export class DBElasticClusterNode extends DBResourceNode {
         return vscode.Uri.parse(
             `https://${region}.console.aws.amazon.com/docdb/home?region=${region}#elastic-cluster-details/${this.arn}`
         )
+    }
+
+    override async copyEndpoint() {
+        // get the full cluster record if we don't have it already
+        if (this.cluster.clusterEndpoint === undefined) {
+            this.cluster = (await this.client.getElasticCluster(this.arn)) ?? this.cluster
+        }
+        await copyToClipboard(this.cluster.clusterEndpoint!, this.name)
     }
 
     public [inspect.custom](): string {

--- a/packages/core/src/docdb/explorer/dbInstanceNode.ts
+++ b/packages/core/src/docdb/explorer/dbInstanceNode.ts
@@ -87,7 +87,7 @@ export class DBInstanceNode extends DBResourceNode {
     }
 
     override copyEndpoint() {
-        return copyToClipboard(this.instance.Endpoint!.Address!, this.name)
+        return copyToClipboard(this.instance.Endpoint?.Address ?? '', this.name)
     }
 
     public [inspect.custom](): string {

--- a/packages/core/src/docdb/explorer/dbInstanceNode.ts
+++ b/packages/core/src/docdb/explorer/dbInstanceNode.ts
@@ -10,6 +10,7 @@ import { DocDBContext, DocDBNodeContext } from './docdbContext'
 import { DBResourceNode } from './dbResourceNode'
 import { DBClusterNode } from './dbClusterNode'
 import { ModifyDBInstanceMessage } from '@aws-sdk/client-docdb'
+import { copyToClipboard } from '../../shared/utilities/messages'
 import { waitUntil } from '../../shared'
 
 /**
@@ -83,6 +84,10 @@ export class DBInstanceNode extends DBResourceNode {
         return vscode.Uri.parse(
             `https://${region}.console.aws.amazon.com/docdb/home?region=${region}#instance-details/${this.name}`
         )
+    }
+
+    override copyEndpoint() {
+        return copyToClipboard(this.instance.Endpoint!.Address!, this.name)
     }
 
     public [inspect.custom](): string {

--- a/packages/core/src/docdb/explorer/dbResourceNode.ts
+++ b/packages/core/src/docdb/explorer/dbResourceNode.ts
@@ -32,6 +32,8 @@ export abstract class DBResourceNode extends AWSTreeNodeBase implements AWSResou
         return await this.client.listResourceTags(this.arn)
     }
 
+    public abstract copyEndpoint(): Promise<void>
+
     public abstract getConsoleUrl(): vscode.Uri
 
     public openInBrowser() {

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -20,7 +20,7 @@ function isElasticCluster(clusterId: string | undefined): boolean | undefined {
 export const DBStorageType = { Standard: 'standard', IOpt1: 'iopt1' } as const
 
 /** A list of Amazon DocumentDB clusters. */
-export interface DBElasticCluster extends DocDBElastic.ClusterInList {}
+export interface DBElasticCluster extends DocDBElastic.Cluster {}
 
 export interface DBInstance extends DocDB.DBInstance {
     IsClusterWriter?: boolean


### PR DESCRIPTION
Users can now copy the resource endpoint to the clipboard for clusters and instances.
They can then use this to connect to the database.