### PR TITLE
AD-1117: Add region / create global cluster

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2061,6 +2061,10 @@
                     "command": "aws.docdb.copyEndpoint",
                     "when": "viewItem =~ /^awsDocDB-/",
                     "group": "0@1"
+                },
+                {
+                    "command": "aws.docdb.addRegion",
+                    "when": "viewItem =~ /^awsDocDB-cluster(?!.*elastic.*)/"
                 }
             ],
             "aws.toolkit.auth": [
@@ -3737,6 +3741,17 @@
                 "title": "%AWS.command.docdb.copyEndpoint%",
                 "category": "%AWS.title%",
                 "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB/",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.docdb.addRegion",
+                "title": "%AWS.command.docdb.addRegion%",
+                "category": "%AWS.title%",
+                "enablement": "(isCloud9 || !aws.isWebExtHost) && viewItem =~ /^awsDocDB-cluster.*-running/",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -275,5 +275,6 @@
     "AWS.command.docdb.stopCluster": "Stop Cluster",
     "AWS.command.docdb.tags": "Tags...",
     "AWS.command.docdb.open": "Open in Browser",
-    "AWS.command.docdb.copyEndpoint": "Copy Endpoint..."
+    "AWS.command.docdb.copyEndpoint": "Copy Endpoint...",
+    "AWS.command.docdb.addRegion": "Add region..."
 }

--- a/packages/core/src/awsexplorer/regionNode.ts
+++ b/packages/core/src/awsexplorer/regionNode.ts
@@ -63,7 +63,7 @@ const serviceCandidates: ServiceNode[] = [
     },
     {
         serviceId: 'docdb',
-        createFn: (regionCode: string) => new DocumentDBNode(new DefaultDocumentDBClient(regionCode)),
+        createFn: (regionCode: string) => new DocumentDBNode(DefaultDocumentDBClient.create(regionCode)),
     },
     {
         serviceId: 'logs',

--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -19,6 +19,7 @@ import { modifyInstance } from './commands/modifyInstance'
 import { rebootInstance } from './commands/rebootInstance'
 import { startCluster, stopCluster } from './commands/commands'
 import { addTag, listTags, removeTag } from './commands/tagCommands'
+import { addRegion } from './commands/addRegion'
 
 /**
  * Activates DocumentDB components.
@@ -84,6 +85,10 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
         Commands.register('aws.docdb.copyEndpoint', async (node?: DBResourceNode) => {
             await node?.copyEndpoint()
+        }),
+
+        Commands.register('aws.docdb.addRegion', async (node: DBClusterNode) => {
+            await addRegion(node)
         })
     )
 }

--- a/packages/core/src/docdb/commands/addRegion.ts
+++ b/packages/core/src/docdb/commands/addRegion.ts
@@ -1,0 +1,96 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from '../../shared/logger'
+import { telemetry } from '../../shared/telemetry'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { DBClusterNode } from '../explorer/dbClusterNode'
+import { DefaultDocumentDBClient } from '../../shared/clients/docdbClient'
+import { ToolkitError } from '../../shared'
+import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { isValidResponse } from '../../shared/wizards/wizard'
+import { CancellationError } from '../../shared/utilities/timeoutUtils'
+import { CreateGlobalClusterWizard } from '../wizards/createGlobalClusterWizard'
+import { CreateDBClusterMessage } from '@aws-sdk/client-docdb'
+import { createInstancesForCluster } from './createCluster'
+
+export async function addRegion(node: DBClusterNode): Promise<void> {
+    if (!node) {
+        throw new ToolkitError('No node specified for AddRegion')
+    }
+
+    return telemetry.docdb_addRegion.run(async () => {
+        if (node.cluster.DBClusterMembers?.length === 0) {
+            void vscode.window.showErrorMessage(
+                localize('AWS.docdb.addRegion.noInstances', 'Cluster must have at least one instance to add a region')
+            )
+            throw new ToolkitError('Cluster must have at least one instance to add a region', { cancelled: true })
+        }
+
+        if (node.cluster.Status !== 'available') {
+            void vscode.window.showErrorMessage(
+                localize('AWS.docdb.deleteCluster.clusterStopped', 'Cluster must be running')
+            )
+            throw new ToolkitError('Cluster not available', { cancelled: true })
+        }
+
+        const wizard = new CreateGlobalClusterWizard(node.regionCode, node.cluster.EngineVersion, node.client, {
+            initState: { GlobalClusterName: undefined }, //TODO: provide if adding to existing global cluster
+        })
+        const response = await wizard.run()
+
+        if (!isValidResponse(response)) {
+            throw new CancellationError('user')
+        }
+
+        let clusterName = response.GlobalClusterName
+        const regionCode = response.RegionCode
+        const primaryCluster = node.cluster
+
+        try {
+            getLogger().info(`Creating global cluster: ${clusterName}`)
+            const globalCluster = await node.client.createGlobalCluster({
+                GlobalClusterIdentifier: response.GlobalClusterName,
+                SourceDBClusterIdentifier: primaryCluster.DBClusterArn,
+            })
+
+            clusterName = response.Cluster.DBClusterIdentifier
+            const input: CreateDBClusterMessage = {
+                GlobalClusterIdentifier: globalCluster?.GlobalClusterIdentifier,
+                DBClusterIdentifier: response.Cluster.DBClusterIdentifier,
+                DeletionProtection: primaryCluster.DeletionProtection,
+                Engine: primaryCluster.Engine,
+                EngineVersion: primaryCluster.EngineVersion,
+                StorageType: primaryCluster.StorageType,
+                StorageEncrypted: globalCluster?.StorageEncrypted,
+            }
+
+            getLogger().info(`Creating cluster: ${clusterName} in region ${regionCode}`)
+            const client = DefaultDocumentDBClient.create(regionCode)
+            const newCluster = await client.createCluster(input)
+
+            if (response.Cluster.DBInstanceCount) {
+                await createInstancesForCluster(
+                    client,
+                    clusterName,
+                    response.Cluster.DBInstanceClass,
+                    response.Cluster.DBInstanceCount
+                )
+            }
+
+            getLogger().info('Created cluster: %O', newCluster)
+            void vscode.window.showInformationMessage(localize('AWS.docdb.addRegion.success', 'Region added'))
+
+            node?.parent.refresh()
+        } catch (e) {
+            getLogger().error(`Failed to create cluster ${clusterName}: %s`, e)
+            void showViewLogsMessage(
+                localize('AWS.docdb.createCluster.error', 'Failed to create cluster: {0}', clusterName)
+            )
+            throw ToolkitError.chain(e, `Failed to create cluster ${clusterName}`)
+        }
+    })
+}

--- a/packages/core/src/docdb/commands/createCluster.ts
+++ b/packages/core/src/docdb/commands/createCluster.ts
@@ -28,7 +28,7 @@ export async function createCluster(node?: DocumentDBNode) {
         }
 
         span.record({ awsRegion: node?.client.regionCode })
-        const wizard = new CreateClusterWizard(node?.regionCode ?? '', {}, node?.client)
+        const wizard = new CreateClusterWizard(node?.client, {})
         const result = await wizard.run()
 
         if (!result) {
@@ -36,7 +36,7 @@ export async function createCluster(node?: DocumentDBNode) {
             throw new ToolkitError('User cancelled wizard', { cancelled: true })
         }
 
-        const clusterName = result.ClusterName
+        const clusterName = result.RegionalCluster.DBClusterIdentifier ?? result.ElasticCluster.clusterName
         getLogger().info(`Creating cluster: ${clusterName}`)
         let cluster
 

--- a/packages/core/src/docdb/wizards/createClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/createClusterWizard.ts
@@ -3,46 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CreateDBClusterCommandInput } from '@aws-sdk/client-docdb'
-import { DBStorageType, DefaultDocumentDBClient, DocumentDBClient } from '../../shared/clients/docdbClient'
-import { validateClusterName, validatePassword, validateUsername } from '../utils'
-import { localize } from '../../shared/utilities/vsCodeUtils'
-import { Wizard, WizardOptions, WizardState } from '../../shared/wizards/wizard'
-import { createInputBox } from '../../shared/ui/inputPrompter'
+import { createCommonButtons } from '../../shared/ui/buttons'
 import { createExitPrompter } from '../../shared/ui/common/exitPrompter'
 import { DataQuickPickItem, createQuickPick } from '../../shared/ui/pickerPrompter'
-import { createCommonButtons } from '../../shared/ui/buttons'
-import { SkipPrompter } from '../../shared/ui/common/skipPrompter'
-import { Auth, CreateClusterInput } from '@aws-sdk/client-docdb-elastic'
-import { Prompter } from '../../shared'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Wizard, WizardOptions } from '../../shared/wizards/wizard'
+import { RegionalClusterConfiguration, RegionalClusterWizard } from './regionalClusterWizard'
+import { ElasticClusterConfiguration, ElasticClusterWizard } from './elasticClusterWizard'
+import { DocumentDBClient } from '../../shared/clients/docdbClient'
 
-const DocDBClusterHelpUrl = 'https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameters.html'
-const DocDBElasticHelpUrl = 'https://docs.aws.amazon.com/documentdb/latest/developerguide/elastic-how-it-works.html'
+const DocDBClusterHelpUrl =
+    'https://docs.aws.amazon.com/documentdb/latest/developerguide/docdb-using-elastic-clusters.html'
 
-const isRegionalCluster = (state: WizardState<CreateClusterState>) => state.ClusterType === 'regional'
-const isElasticCluster = (state: WizardState<CreateClusterState>) => state.ClusterType === 'elastic'
-
-export interface RegionalClusterConfiguration extends CreateDBClusterCommandInput {
-    // These options cannot be changed later
-    EngineVersion?: string | undefined
-    MasterUsername?: string | undefined
-    MasterUserPassword?: string | undefined
-    StorageEncrypted?: boolean | undefined
-    KmsKeyId?: string | undefined
-    DBSubnetGroupName?: string | undefined
-    VpcSecurityGroupIds?: string[] | undefined
-    // Instance fields
-    DBInstanceCount?: number | undefined
-    DBInstanceClass?: string | undefined
-}
-
-export interface ElasticClusterConfiguration extends CreateClusterInput {}
+type ClusterType = 'regional' | 'elastic' | undefined
 
 export interface CreateClusterState {
-    ClusterType: string
-    ClusterName: string
+    ClusterType: ClusterType
     readonly RegionalCluster: RegionalClusterConfiguration
-    readonly ElasticCluster: Partial<ElasticClusterConfiguration>
+    readonly ElasticCluster: ElasticClusterConfiguration
 }
 
 /**
@@ -51,103 +29,28 @@ export interface CreateClusterState {
 export class CreateClusterWizard extends Wizard<CreateClusterState> {
     title: string
     constructor(
-        region: string,
-        options: WizardOptions<CreateClusterState> = {},
-        readonly client: DocumentDBClient = new DefaultDocumentDBClient(region)
+        readonly client: DocumentDBClient,
+        options: WizardOptions<CreateClusterState> = {}
     ) {
         super({
             initState: options.initState,
             implicitState: options.implicitState,
             exitPrompterProvider: createExitPrompter,
         })
-        this.client = client
         this.title = localize('AWS.docdb.createCluster.title', 'Create DocumentDB Cluster')
     }
 
     public override async init(): Promise<this> {
-        const form = this.form
+        this.form.ClusterType.bindPrompter(() => createClusterTypePrompter())
 
-        form.ClusterName.bindPrompter(
-            () =>
-                createInputBox({
-                    step: 1,
-                    title: this.title,
-                    prompt: localize('AWS.docdb.createCluster.name.prompt', 'Specify a unique cluster name'),
-                    validateInput: validateClusterName,
-                }),
-            {
-                relativeOrder: 1,
-            }
-        )
-        form.RegionalCluster.Engine.setDefault(() => 'docdb')
-        form.RegionalCluster.DBClusterIdentifier.setDefault((state) => state.ClusterName)
-        form.ElasticCluster.clusterName.setDefault((state) => state.ClusterName)
-
-        form.ClusterType.bindPrompter(() => createClusterTypePrompter(), {
-            relativeOrder: 2,
+        const regionalClusterWizard = await new RegionalClusterWizard(this.client, this.title).init()
+        this.form.RegionalCluster.applyBoundForm(regionalClusterWizard.boundForm, {
+            showWhen: (state) => state.ClusterType === 'regional',
         })
 
-        form.RegionalCluster.EngineVersion.bindPrompter(async () => await createEngineVersionPrompter(this.client), {
-            showWhen: isRegionalCluster,
-        })
-        form.RegionalCluster.MasterUsername.bindPrompter(() => createUsernamePrompter(this.title), {
-            showWhen: isRegionalCluster,
-        })
-        form.RegionalCluster.MasterUserPassword.bindPrompter(() => createPasswordPrompter(this.title), {
-            showWhen: isRegionalCluster,
-        })
-        form.RegionalCluster.StorageEncrypted.bindPrompter(() => createEncryptedStoragePrompter(), {
-            showWhen: isRegionalCluster,
-        })
-
-        form.RegionalCluster.DBInstanceCount.bindPrompter(
-            () =>
-                createQuickPick(instanceCountItems(3), {
-                    title: localize('AWS.docdb.createCluster.dbInstanceCount.prompt', 'Number of instances'),
-                    buttons: createCommonButtons(DocDBClusterHelpUrl),
-                }),
-            {
-                showWhen: isRegionalCluster,
-                setDefault: () => 3,
-            }
-        )
-
-        form.RegionalCluster.DBInstanceClass.bindPrompter(
-            async (state) => await createInstanceClassPrompter(this.client, state.RegionalCluster!.EngineVersion!),
-            {
-                showWhen: isRegionalCluster,
-                setDefault: () => 'db.t3.medium',
-            }
-        )
-
-        form.ElasticCluster.adminUserName.bindPrompter(() => createUsernamePrompter(this.title), {
-            showWhen: isElasticCluster,
-        })
-        form.ElasticCluster.adminUserPassword.bindPrompter(() => createPasswordPrompter(this.title), {
-            showWhen: isElasticCluster,
-        })
-        form.ElasticCluster.authType.setDefault(() => Auth.PLAIN_TEXT)
-        form.ElasticCluster.shardCount.bindPrompter(() => createShardCountPrompter(this.title), {
-            showWhen: isElasticCluster,
-            setDefault: () => 2,
-        })
-        form.ElasticCluster.shardInstanceCount.bindPrompter(
-            () =>
-                createQuickPick(instanceCountItems(2), {
-                    title: localize(
-                        'AWS.docdb.createCluster.dbInstanceCount.prompt',
-                        'The number of replica instances applying to all shards in the elastic cluster'
-                    ),
-                    buttons: createCommonButtons(DocDBElasticHelpUrl),
-                }),
-            {
-                showWhen: isElasticCluster,
-                setDefault: () => 2,
-            }
-        )
-        form.ElasticCluster.shardCapacity.bindPrompter(() => createShardCapacityPrompter(this.title), {
-            showWhen: isElasticCluster,
-            setDefault: () => 2,
+        const elasticClusterWizard = new ElasticClusterWizard(this.client, this.title)
+        this.form.ElasticCluster.applyBoundForm(elasticClusterWizard.boundForm, {
+            showWhen: (state) => state.ClusterType === 'elastic',
         })
 
         return this
@@ -155,7 +58,7 @@ export class CreateClusterWizard extends Wizard<CreateClusterState> {
 }
 
 function createClusterTypePrompter() {
-    const regionalType: DataQuickPickItem<string> = {
+    const regionalType: DataQuickPickItem<ClusterType> = {
         data: 'regional',
         label: localize('AWS.docdb.createCluster.clusterType.regional.label', 'Instance Based Cluster'),
         detail: localize(
@@ -163,7 +66,7 @@ function createClusterTypePrompter() {
             'Instance based cluster can scale your database to millions of reads per second and up to 128 TiB of storage capacity. With instance based clusters you can choose your instance type based on your requirements.'
         ),
     }
-    const elasticType: DataQuickPickItem<string> = {
+    const elasticType: DataQuickPickItem<ClusterType> = {
         data: 'elastic',
         label: localize('AWS.docdb.createCluster.clusterType.elastic.label', 'Elastic Cluster'),
         detail: localize(
@@ -173,142 +76,7 @@ function createClusterTypePrompter() {
     }
 
     return createQuickPick([regionalType, elasticType], {
-        step: 1,
         title: localize('AWS.docdb.createCluster.clusterType.prompt', 'Cluster type'),
         buttons: createCommonButtons(DocDBClusterHelpUrl),
-    })
-}
-
-function createUsernamePrompter(title: string) {
-    return createInputBox({
-        step: 3,
-        title,
-        prompt: localize('AWS.docdb.createCluster.username.prompt', 'Specify a login username'),
-        validateInput: validateUsername,
-        buttons: createCommonButtons(DocDBClusterHelpUrl),
-    })
-}
-
-function createPasswordPrompter(title: string) {
-    return createInputBox({
-        step: 4,
-        title,
-        prompt: localize('AWS.docdb.createCluster.password.prompt', 'Specify a login password (8 characters minimum)'),
-        password: true,
-        validateInput: validatePassword,
-        buttons: createCommonButtons(DocDBClusterHelpUrl),
-    })
-}
-
-function createEncryptedStoragePrompter() {
-    return createQuickPick(
-        [
-            {
-                label: localize('AWS.docdb.createCluster.storage.encrypted', 'Encrypt'),
-                description: '(recommended)',
-                data: true,
-            },
-            {
-                label: localize('AWS.docdb.createCluster.storage.notEncrypted', "Don't encrypt"),
-                data: false,
-            },
-        ],
-        {
-            title: localize('AWS.docdb.createCluster.storageEncrypted.prompt', 'Specify storage encryption'),
-            buttons: createCommonButtons(DocDBClusterHelpUrl),
-        }
-    )
-}
-
-async function createEngineVersionPrompter(docdbClient: DocumentDBClient) {
-    const versions = await docdbClient.listEngineVersions()
-    // sort in descending order
-    versions.sort((a, b) => b.EngineVersion!.localeCompare(a.EngineVersion!))
-
-    const items: DataQuickPickItem<string>[] = versions.map((v) => {
-        return {
-            label: v.EngineVersion ?? '',
-            data: v.EngineVersion,
-        }
-    })
-
-    if (items.length === 0) {
-        items.push({ label: '5.0.0 (default)', data: '5.0.0' })
-    }
-
-    items[0].picked = true
-
-    return createQuickPick(items, {
-        title: localize('AWS.docdb.createCluster.engineVersion.prompt', 'Select engine version'),
-        buttons: createCommonButtons(DocDBClusterHelpUrl),
-    })
-}
-
-async function createInstanceClassPrompter(docdbClient: DocumentDBClient, engineVersion: string) {
-    const options = await docdbClient.listInstanceClassOptions(engineVersion, DBStorageType.Standard)
-
-    const items: DataQuickPickItem<string>[] = options.map((option) => {
-        return {
-            data: option.DBInstanceClass,
-            label: option.DBInstanceClass ?? '(unknown)',
-            description: undefined,
-            detail: undefined,
-        }
-    })
-
-    if (items.length === 0) {
-        return new SkipPrompter('db.t3.medium')
-    }
-
-    return createQuickPick(items, {
-        title: localize('AWS.docdb.createInstance.instanceClass.prompt', 'Select instance class'),
-        buttons: createCommonButtons(DocDBClusterHelpUrl),
-    })
-}
-
-function instanceCountItems(defaultCount: number, max: number = 16): DataQuickPickItem<number>[] {
-    const items = []
-
-    for (let index = 1; index <= max; index++) {
-        const item: DataQuickPickItem<number> = {
-            label: index.toString(),
-            data: index,
-            description: index === defaultCount ? '(recommended)' : undefined,
-        }
-        items.push(item)
-    }
-
-    return items
-}
-
-function createShardCountPrompter(title: string): Prompter<number> {
-    const maxShardCount = 32
-    const prompter = createInputBox({
-        title,
-        prompt: localize('AWS.docdb.createCluster.shardCount.prompt', 'Number of shards the Elastic Cluster will use'),
-        validateInput: (value) => {
-            const num = parseInt(value)
-            if (num < 1 || num > maxShardCount || isNaN(num)) {
-                return localize(
-                    'AWS.docdb.createCluster.shardCount.invalidValue',
-                    `Enter a numeric value between 1 and ${maxShardCount}`
-                )
-            }
-            return undefined
-        },
-        buttons: createCommonButtons(DocDBElasticHelpUrl),
-    })
-    return prompter.transform((value) => parseInt(value))
-}
-
-function createShardCapacityPrompter(title: string): Prompter<number> {
-    const items = [2, 4, 8, 16, 32, 64].map<DataQuickPickItem<number>>((data) => ({
-        data,
-        label: data.toString(),
-    }))
-    return createQuickPick(items, {
-        title,
-        placeholder: localize('AWS.docdb.createCluster.shardCapacity.placeholder', 'vCPU capacity of shard instances'),
-        buttons: createCommonButtons(DocDBElasticHelpUrl),
     })
 }

--- a/packages/core/src/docdb/wizards/createGlobalClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/createGlobalClusterWizard.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globals } from '../../shared'
+import { DocumentDBClient } from '../../shared/clients/docdbClient'
+import { createExitPrompter } from '../../shared/ui/common/exitPrompter'
+import { createRegionPrompter } from '../../shared/ui/common/region'
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Wizard, WizardOptions } from '../../shared/wizards/wizard'
+import { validateClusterName } from '../utils'
+import { RegionalClusterConfiguration, RegionalClusterWizard } from './regionalClusterWizard'
+
+export interface CreateGlobalClusterState {
+    RegionCode: string
+    GlobalClusterName: string
+    readonly Cluster: RegionalClusterConfiguration
+}
+
+/**
+ * A wizard to prompt configuration of a new global cluster
+ */
+export class CreateGlobalClusterWizard extends Wizard<CreateGlobalClusterState> {
+    constructor(
+        readonly region: string,
+        readonly engineVersion: string | undefined,
+        readonly client: DocumentDBClient,
+        options: WizardOptions<CreateGlobalClusterState> = {}
+    ) {
+        super({
+            initState: options.initState,
+            implicitState: options.implicitState,
+            exitPrompterProvider: createExitPrompter,
+        })
+    }
+
+    public override async init(): Promise<this> {
+        this.form.RegionCode.bindPrompter(async () => {
+            const regions = globals.regionProvider.getRegions().filter((r) => r.id !== this.region)
+            return createRegionPrompter(regions, {
+                serviceFilter: 'docdb',
+                title: localize('AWS.docdb.addRegion.region.prompt', 'Secondary region'),
+            }).transform((region) => region.id)
+        })
+
+        this.form.GlobalClusterName.bindPrompter(
+            () =>
+                createInputBox({
+                    title: localize('AWS.docdb.addRegion.name.title', 'Global Cluster Id'),
+                    prompt: localize(
+                        'AWS.docdb.addRegion.name.prompt',
+                        'Specify a unique identifier for the global cluster'
+                    ),
+                    validateInput: validateClusterName,
+                }),
+            {
+                showWhen: (state) => state.GlobalClusterName === undefined,
+            }
+        )
+
+        const title = localize('AWS.docdb.addRegion.cluster.title', 'Secondary cluster')
+        const regionalClusterWizard = await new RegionalClusterWizard(this.client, title, false, {
+            initState: { EngineVersion: this.engineVersion },
+        }).init()
+        this.form.Cluster.applyBoundForm(regionalClusterWizard.boundForm)
+
+        return this
+    }
+}

--- a/packages/core/src/docdb/wizards/createInstanceWizard.ts
+++ b/packages/core/src/docdb/wizards/createInstanceWizard.ts
@@ -31,7 +31,7 @@ export class CreateInstanceWizard extends Wizard<CreateInstanceState> {
         region: string,
         cluster: DBCluster,
         options: WizardOptions<CreateInstanceState> = {},
-        readonly client: DocumentDBClient = new DefaultDocumentDBClient(region)
+        readonly client: DocumentDBClient = DefaultDocumentDBClient.create(region)
     ) {
         super({
             initState: {

--- a/packages/core/src/docdb/wizards/elasticClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/elasticClusterWizard.ts
@@ -1,0 +1,132 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DocumentDBClient } from '../../shared/clients/docdbClient'
+import { validateClusterName, validatePassword, validateUsername } from '../utils'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Wizard } from '../../shared/wizards/wizard'
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { DataQuickPickItem, createQuickPick } from '../../shared/ui/pickerPrompter'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { Auth, CreateClusterInput } from '@aws-sdk/client-docdb-elastic'
+import { Prompter } from '../../shared'
+
+const DocDBElasticHelpUrl = 'https://docs.aws.amazon.com/documentdb/latest/developerguide/elastic-how-it-works.html'
+const DefaultShardCount = 2
+const DefaultCapacity = 2
+
+export interface ElasticClusterConfiguration extends Partial<CreateClusterInput> {}
+
+/**
+ * A wizard to prompt configuration of a new cluster
+ */
+export class ElasticClusterWizard extends Wizard<ElasticClusterConfiguration> {
+    constructor(
+        readonly client: DocumentDBClient,
+        readonly title: string
+    ) {
+        super()
+        this.client = client
+        const form = this.form
+
+        form.clusterName.bindPrompter(() =>
+            createInputBox({
+                title: this.title,
+                prompt: localize('AWS.docdb.createCluster.name.prompt', 'Specify a unique cluster name'),
+                validateInput: validateClusterName,
+                buttons: createCommonButtons(DocDBElasticHelpUrl),
+            })
+        )
+
+        form.adminUserName.bindPrompter(() => createUsernamePrompter(this.title))
+        form.adminUserPassword.bindPrompter(() => createPasswordPrompter(this.title))
+        form.authType.setDefault(() => Auth.PLAIN_TEXT)
+        form.shardCount.bindPrompter(() => createShardCountPrompter(this.title), {
+            setDefault: () => DefaultShardCount,
+        })
+        form.shardInstanceCount.bindPrompter(
+            () =>
+                createQuickPick(instanceCountItems(2), {
+                    title: localize(
+                        'AWS.docdb.createCluster.dbInstanceCount.prompt',
+                        'The number of replica instances applying to all shards in the elastic cluster'
+                    ),
+                    buttons: createCommonButtons(DocDBElasticHelpUrl),
+                }),
+            { setDefault: () => 2 }
+        )
+        form.shardCapacity.bindPrompter(() => createShardCapacityPrompter(this.title), {
+            setDefault: () => DefaultCapacity,
+        })
+
+        return this
+    }
+}
+
+function createUsernamePrompter(title: string) {
+    return createInputBox({
+        title,
+        prompt: localize('AWS.docdb.createCluster.username.prompt', 'Specify a login username'),
+        validateInput: validateUsername,
+        buttons: createCommonButtons(DocDBElasticHelpUrl),
+    })
+}
+
+function createPasswordPrompter(title: string) {
+    return createInputBox({
+        title,
+        prompt: localize('AWS.docdb.createCluster.password.prompt', 'Specify a login password (8 characters minimum)'),
+        password: true,
+        validateInput: validatePassword,
+        buttons: createCommonButtons(DocDBElasticHelpUrl),
+    })
+}
+
+function createShardCountPrompter(title: string): Prompter<number> {
+    const maxShardCount = 32
+    const prompter = createInputBox({
+        title,
+        prompt: localize('AWS.docdb.createCluster.shardCount.prompt', 'Number of shards the Elastic Cluster will use'),
+        validateInput: (value) => {
+            const num = parseInt(value)
+            if (num < 1 || num > maxShardCount || isNaN(num)) {
+                return localize(
+                    'AWS.docdb.createCluster.shardCount.invalidValue',
+                    `Enter a numeric value between 1 and ${maxShardCount}`
+                )
+            }
+            return undefined
+        },
+        buttons: createCommonButtons(DocDBElasticHelpUrl),
+    })
+    return prompter.transform((value) => parseInt(value))
+}
+
+function createShardCapacityPrompter(title: string): Prompter<number> {
+    const items = [2, 4, 8, 16, 32, 64].map<DataQuickPickItem<number>>((data) => ({
+        data,
+        label: data.toString(),
+    }))
+    return createQuickPick(items, {
+        title,
+        placeholder: localize('AWS.docdb.createCluster.shardCapacity.placeholder', 'vCPU capacity of shard instances'),
+        buttons: createCommonButtons(DocDBElasticHelpUrl),
+    })
+}
+
+function instanceCountItems(defaultCount: number, max: number = 16): DataQuickPickItem<number>[] {
+    const items = []
+
+    for (let index = 1; index <= max; index++) {
+        const item: DataQuickPickItem<number> = {
+            label: index.toString(),
+            data: index,
+            description: index === defaultCount ? '(recommended)' : undefined,
+        }
+        items.push(item)
+    }
+
+    return items
+}

--- a/packages/core/src/docdb/wizards/regionalClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/regionalClusterWizard.ts
@@ -1,0 +1,187 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CreateDBClusterCommandInput } from '@aws-sdk/client-docdb'
+import { DBStorageType, DocumentDBClient } from '../../shared/clients/docdbClient'
+import { validateClusterName, validatePassword, validateUsername } from '../utils'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Wizard } from '../../shared/wizards/wizard'
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { DataQuickPickItem, createQuickPick } from '../../shared/ui/pickerPrompter'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { SkipPrompter } from '../../shared/ui/common/skipPrompter'
+
+const DocDBClusterHelpUrl = 'https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameters.html'
+
+export interface RegionalClusterConfiguration extends CreateDBClusterCommandInput {
+    DBClusterIdentifier: string
+    // These options cannot be changed later
+    EngineVersion: string
+    MasterUsername: string
+    MasterUserPassword: string
+    StorageEncrypted: boolean
+    KmsKeyId?: string | undefined
+    DBSubnetGroupName?: string | undefined
+    VpcSecurityGroupIds?: string[] | undefined
+    // Instance fields
+    DBInstanceCount?: number | undefined
+    DBInstanceClass?: string | undefined
+}
+
+/**
+ * A wizard to prompt configuration of a new cluster
+ */
+export class RegionalClusterWizard extends Wizard<RegionalClusterConfiguration> {
+    constructor(
+        readonly client: DocumentDBClient,
+        readonly title: string
+    ) {
+        super()
+        this.client = client
+    }
+
+    public override async init(): Promise<this> {
+        const form = this.form
+
+        form.DBClusterIdentifier.bindPrompter(
+            () =>
+                createInputBox({
+                    step: 1,
+                    title: this.title,
+                    prompt: localize('AWS.docdb.createCluster.name.prompt', 'Specify a unique cluster name'),
+                    validateInput: validateClusterName,
+                    buttons: createCommonButtons(DocDBClusterHelpUrl),
+                }),
+            { relativeOrder: 1 }
+        )
+
+        form.Engine.setDefault(() => 'docdb')
+        form.EngineVersion.bindPrompter(async () => await createEngineVersionPrompter(this.client))
+        form.MasterUsername.bindPrompter(() => createUsernamePrompter(this.title))
+        form.MasterUserPassword.bindPrompter(() => createPasswordPrompter(this.title))
+        form.StorageEncrypted.bindPrompter(() => createEncryptedStoragePrompter())
+
+        form.DBInstanceCount.bindPrompter(
+            () =>
+                createQuickPick(instanceCountItems(3), {
+                    title: localize('AWS.docdb.createCluster.dbInstanceCount.prompt', 'Number of instances'),
+                    buttons: createCommonButtons(DocDBClusterHelpUrl),
+                }),
+            {
+                setDefault: () => 3,
+            }
+        )
+
+        form.DBInstanceClass.bindPrompter(
+            async (state) => await createInstanceClassPrompter(this.client, state.EngineVersion!),
+            { setDefault: () => 'db.t3.medium' }
+        )
+
+        return this
+    }
+}
+
+function createUsernamePrompter(title: string) {
+    return createInputBox({
+        step: 3,
+        title,
+        prompt: localize('AWS.docdb.createCluster.username.prompt', 'Specify a login username'),
+        validateInput: validateUsername,
+        buttons: createCommonButtons(DocDBClusterHelpUrl),
+    })
+}
+
+function createPasswordPrompter(title: string) {
+    return createInputBox({
+        step: 4,
+        title,
+        prompt: localize('AWS.docdb.createCluster.password.prompt', 'Specify a login password (8 characters minimum)'),
+        password: true,
+        validateInput: validatePassword,
+        buttons: createCommonButtons(DocDBClusterHelpUrl),
+    })
+}
+
+function createEncryptedStoragePrompter() {
+    return createQuickPick(
+        [
+            {
+                label: localize('AWS.docdb.createCluster.storage.encrypted', 'Encrypt'),
+                description: '(recommended)',
+                data: true,
+            },
+            {
+                label: localize('AWS.docdb.createCluster.storage.notEncrypted', "Don't encrypt"),
+                data: false,
+            },
+        ],
+        {
+            title: localize('AWS.docdb.createCluster.storageEncrypted.prompt', 'Specify storage encryption'),
+            buttons: createCommonButtons(DocDBClusterHelpUrl),
+        }
+    )
+}
+
+async function createEngineVersionPrompter(docdbClient: DocumentDBClient) {
+    const versions = await docdbClient.listEngineVersions()
+    // sort in descending order
+    versions.sort((a, b) => b.EngineVersion!.localeCompare(a.EngineVersion!))
+
+    const items: DataQuickPickItem<string>[] = versions.map((v) => {
+        return {
+            label: v.EngineVersion ?? '',
+            data: v.EngineVersion,
+        }
+    })
+
+    if (items.length === 0) {
+        items.push({ label: '5.0.0 (default)', data: '5.0.0' })
+    }
+
+    items[0].picked = true
+
+    return createQuickPick(items, {
+        title: localize('AWS.docdb.createCluster.engineVersion.prompt', 'Select engine version'),
+        buttons: createCommonButtons(DocDBClusterHelpUrl),
+    })
+}
+
+async function createInstanceClassPrompter(docdbClient: DocumentDBClient, engineVersion: string) {
+    const options = await docdbClient.listInstanceClassOptions(engineVersion, DBStorageType.Standard)
+
+    const items: DataQuickPickItem<string>[] = options.map((option) => {
+        return {
+            data: option.DBInstanceClass,
+            label: option.DBInstanceClass ?? '(unknown)',
+            description: undefined,
+            detail: undefined,
+        }
+    })
+
+    if (items.length === 0) {
+        return new SkipPrompter('db.t3.medium')
+    }
+
+    return createQuickPick(items, {
+        title: localize('AWS.docdb.createInstance.instanceClass.prompt', 'Select instance class'),
+        buttons: createCommonButtons(DocDBClusterHelpUrl),
+    })
+}
+
+//TODO: Make this it's own picker class
+function instanceCountItems(defaultCount: number, max: number = 16): DataQuickPickItem<number>[] {
+    const items = []
+
+    for (let index = 1; index <= max; index++) {
+        const item: DataQuickPickItem<number> = {
+            label: index.toString(),
+            data: index,
+            description: index === defaultCount ? '(recommended)' : undefined,
+        }
+        items.push(item)
+    }
+
+    return items
+}

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -29,7 +29,11 @@ export interface DBInstance extends DocDB.DBInstance {
 export type DocumentDBClient = InterfaceNoSymbol<DefaultDocumentDBClient>
 
 export class DefaultDocumentDBClient {
-    public constructor(public readonly regionCode: string) {}
+    static create(regionCode: string): DocumentDBClient {
+        return new DefaultDocumentDBClient(regionCode)
+    }
+
+    private constructor(public readonly regionCode: string) {}
 
     private async getSdkConfig() {
         const credentials = await globals.awsContext.getCredentials()

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -159,6 +159,14 @@ export class DefaultDocumentDBClient {
         return response.cluster
     }
 
+    public async createGlobalCluster(
+        input: DocDB.CreateGlobalClusterCommandInput
+    ): Promise<DocDB.GlobalCluster | undefined> {
+        const command = new DocDB.CreateGlobalClusterCommand(input)
+        const response = await this.executeCommand<DocDB.CreateGlobalClusterCommandOutput>(command)
+        return response.GlobalCluster
+    }
+
     public async createClusterSnapshot(
         input: DocDBElastic.CreateClusterSnapshotInput
     ): Promise<DocDBElastic.ClusterSnapshot | undefined> {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1443,6 +1443,10 @@
         {
             "name": "docdb_removeTag",
             "description": "User clicked on remove tag command"
+        },
+        {
+            "name": "docdb_addRegion",
+            "description": "User clicked on add region command"
         }
     ]
 }

--- a/packages/core/src/shared/wizards/wizard.ts
+++ b/packages/core/src/shared/wizards/wizard.ts
@@ -134,7 +134,7 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
         this._estimator = estimator
     }
 
-    public constructor(private readonly options: WizardOptions<TState> = {}) {
+    public constructor(protected readonly options: WizardOptions<TState> = {}) {
         this.stateController = new StateMachineController(options.initState as TState)
         this.__form = options.initForm ?? new WizardForm()
         this._exitStep =

--- a/packages/core/src/test/docdb/commands/addRegion.test.ts
+++ b/packages/core/src/test/docdb/commands/addRegion.test.ts
@@ -1,0 +1,159 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import * as sinon from 'sinon'
+import * as vscode from 'vscode'
+import { assertTelemetry } from '../../testUtil'
+import { getTestWindow } from '../../shared/vscode/window'
+import { globals } from '../../../shared'
+import { DBStorageType, DefaultDocumentDBClient, DocumentDBClient } from '../../../shared/clients/docdbClient'
+import { addRegion } from '../../../docdb/commands/addRegion'
+import { DBClusterNode } from '../../../docdb/explorer/dbClusterNode'
+import { DocumentDBNode } from '../../../docdb/explorer/docdbNode'
+
+describe('addRegionCommand', function () {
+    const globalClusterName = 'docdb-global'
+    const clusterName = 'docdb-1234'
+    const cluster = {
+        DBClusterArn: 'arn:docdb-1234',
+        Status: 'available',
+    }
+    let docdb: DocumentDBClient
+    let node: DBClusterNode
+    let sandbox: sinon.SinonSandbox
+    let spyExecuteCommand: sinon.SinonSpy
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+        spyExecuteCommand = sandbox.spy(vscode.commands, 'executeCommand')
+        sandbox.stub(globals.regionProvider, 'isServiceInRegion').returns(true)
+        sandbox.stub(globals.regionProvider, 'getRegions').returns([
+            { id: 'us-test-1', name: 'Test Region 1' },
+            { id: 'us-test-2', name: 'Test Region 2' },
+        ])
+
+        docdb = { regionCode: 'us-test-1' } as DocumentDBClient
+        docdb.listEngineVersions = sinon.stub().resolves([{ EngineVersion: 'test-version' }])
+        docdb.listInstanceClassOptions = sinon
+            .stub()
+            .resolves([{ DBInstanceClass: 'db.r5.large', StorageType: DBStorageType.Standard }])
+
+        sandbox.stub(DefaultDocumentDBClient, 'create').returns(docdb)
+
+        const parentNode = new DocumentDBNode(docdb)
+        node = new DBClusterNode(parentNode, cluster, docdb)
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+        getTestWindow().dispose()
+    })
+
+    function setupWizard() {
+        getTestWindow().onDidShowInputBox((input) => {
+            let value: string
+            if (input.prompt?.includes('global')) {
+                value = globalClusterName
+            } else if (input.prompt?.includes('cluster name')) {
+                value = clusterName
+            } else {
+                value = ''
+            }
+            input.acceptValue(value)
+        })
+
+        getTestWindow().onDidShowQuickPick(async (picker) => {
+            await picker.untilReady()
+            picker.acceptItem(picker.items[0])
+        })
+    }
+
+    it('prompts for new region and cluster params, creates cluster, shows success, and refreshes node', async function () {
+        // arrange
+        const createGlobalClusterStub = sinon.stub().resolves({
+            GlobalClusterIdentifier: globalClusterName,
+        })
+        const createClusterStub = sinon.stub().resolves({
+            DBClusterIdentifier: clusterName,
+        })
+        const createInstanceStub = sinon.stub().resolves()
+        docdb.createGlobalCluster = createGlobalClusterStub
+        docdb.createCluster = createClusterStub
+        docdb.createInstance = createInstanceStub
+        setupWizard()
+
+        // act
+        await addRegion(node)
+
+        // assert
+        getTestWindow().getFirstMessage().assertInfo('Region added')
+
+        assert(
+            createGlobalClusterStub.calledOnceWithExactly({
+                GlobalClusterIdentifier: globalClusterName,
+                SourceDBClusterIdentifier: cluster.DBClusterArn,
+            })
+        )
+
+        assert(
+            createClusterStub.calledOnceWith(
+                sinon.match({
+                    DBClusterIdentifier: clusterName,
+                    GlobalClusterIdentifier: globalClusterName,
+                })
+            )
+        )
+
+        assert(
+            createInstanceStub.calledOnceWith(
+                sinon.match({
+                    Engine: 'docdb',
+                    DBClusterIdentifier: clusterName,
+                    DBInstanceIdentifier: clusterName,
+                    DBInstanceClass: 'db.r5.large',
+                })
+            )
+        )
+
+        sandbox.assert.calledWith(spyExecuteCommand, 'aws.refreshAwsExplorerNode', node.parent)
+
+        assertTelemetry('docdb_addRegion', { result: 'Succeeded' })
+    })
+
+    it('does nothing when prompt is cancelled', async function () {
+        // arrange
+        const stub = sinon.stub()
+        docdb.createGlobalCluster = stub
+        getTestWindow().onDidShowQuickPick((input) => input.hide())
+
+        // act
+        await assert.rejects(addRegion(node))
+
+        // assert
+        assert(stub.notCalled)
+
+        assertTelemetry('docdb_addRegion', { result: 'Cancelled' })
+    })
+
+    it('shows an error when cluster creation fails', async function () {
+        // arrange
+        docdb.createGlobalCluster = sinon.stub().resolves({
+            GlobalClusterIdentifier: globalClusterName,
+        })
+        docdb.createCluster = sinon.stub().rejects()
+        setupWizard()
+
+        // act
+        await assert.rejects(addRegion(node))
+
+        // assert
+        getTestWindow()
+            .getFirstMessage()
+            .assertError(/Failed to create cluster: docdb-1234/)
+
+        assertTelemetry('docdb_addRegion', { result: 'Failed' })
+    })
+})

--- a/packages/core/src/test/docdb/commands/createCluster.test.ts
+++ b/packages/core/src/test/docdb/commands/createCluster.test.ts
@@ -115,6 +115,7 @@ describe('createClusterCommand', function () {
         const stub = sinon.stub()
         docdb.createCluster = stub
         getTestWindow().onDidShowInputBox((input) => input.hide())
+        getTestWindow().onDidShowQuickPick((input) => input.hide())
 
         // act
         await assert.rejects(createCluster(node))

--- a/packages/core/src/test/docdb/wizards/createClusterWizard.test.ts
+++ b/packages/core/src/test/docdb/wizards/createClusterWizard.test.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
+import { CreateClusterState, CreateClusterWizard } from '../../../docdb/wizards/createClusterWizard'
+
+describe('CreateClusterWizard', function () {
+    let tester: WizardTester<CreateClusterState>
+
+    beforeEach(async function () {
+        const wizard = new CreateClusterWizard({} as any)
+        tester = await createWizardTester(wizard)
+    })
+
+    it('prompts for cluster type first', function () {
+        tester.ClusterType.assertShowFirst()
+    })
+
+    it('prompts for regional cluster when selected', function () {
+        tester.ClusterType.applyInput('regional')
+        tester.RegionalCluster.assertShowAny()
+        tester.ElasticCluster.assertDoesNotShowAny()
+    })
+
+    it('prompts for elastic cluster when selected', function () {
+        tester.ClusterType.applyInput('elastic')
+        tester.RegionalCluster.assertDoesNotShowAny()
+        tester.ElasticCluster.assertShowAny()
+    })
+})

--- a/packages/core/src/test/docdb/wizards/createGlobalClusterWizard.test.ts
+++ b/packages/core/src/test/docdb/wizards/createGlobalClusterWizard.test.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
+import { CreateGlobalClusterState, CreateGlobalClusterWizard } from '../../../docdb/wizards/createGlobalClusterWizard'
+
+describe('CreateGlobalClusterWizard', function () {
+    let tester: WizardTester<CreateGlobalClusterState>
+
+    beforeEach(async function () {
+        const wizard = new CreateGlobalClusterWizard('region', {} as any)
+        tester = await createWizardTester(wizard)
+    })
+
+    it('prompts for secondary region and global cluster name', function () {
+        tester.RegionCode.assertShowFirst()
+        tester.GlobalClusterName.assertShowSecond()
+        tester.Cluster.assertShowAny()
+    })
+})

--- a/packages/core/src/test/docdb/wizards/elasticClusterWizard.test.ts
+++ b/packages/core/src/test/docdb/wizards/elasticClusterWizard.test.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
+import { ElasticClusterConfiguration, ElasticClusterWizard } from '../../../docdb/wizards/elasticClusterWizard'
+
+describe('ElasticClusterWizard', function () {
+    let tester: WizardTester<ElasticClusterConfiguration>
+
+    beforeEach(async function () {
+        const wizard = new ElasticClusterWizard({} as any, 'title')
+        tester = await createWizardTester(wizard)
+    })
+
+    it('prompts for properties in the correct order', function () {
+        tester.clusterName.assertShow(1)
+        tester.adminUserName.assertShow(2)
+        tester.adminUserPassword.assertShow(3)
+        tester.shardCount.assertShow(4)
+        tester.shardInstanceCount.assertShow(5)
+        tester.shardCapacity.assertShow(6)
+        tester.authType.assertDoesNotShow()
+    })
+})

--- a/packages/core/src/test/docdb/wizards/regionalClusterWizard.test.ts
+++ b/packages/core/src/test/docdb/wizards/regionalClusterWizard.test.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
+import { RegionalClusterConfiguration, RegionalClusterWizard } from '../../../docdb/wizards/regionalClusterWizard'
+
+describe('RegionalClusterWizard', function () {
+    let tester: WizardTester<RegionalClusterConfiguration>
+
+    beforeEach(async function () {
+        const wizard = new RegionalClusterWizard({} as any, 'title')
+        tester = await createWizardTester(wizard)
+    })
+
+    it('prompts for properties in the correct order', function () {
+        tester.DBClusterIdentifier.assertShow(1)
+        tester.Engine.assertDoesNotShow()
+        tester.EngineVersion.assertShow(2)
+        tester.MasterUsername.assertShow(3)
+        tester.MasterUserPassword.assertShow(4)
+        tester.StorageEncrypted.assertShow(5)
+        tester.DBInstanceCount.assertShow(6)
+        tester.DBInstanceClass.assertShow(7)
+    })
+})

--- a/packages/core/src/test/shared/clients/defaultDocdbClient.test.ts
+++ b/packages/core/src/test/shared/clients/defaultDocdbClient.test.ts
@@ -23,7 +23,7 @@ describe('DefaultDocumentDBClient', function () {
     })
 
     function createClient({ regionCode = region }: { regionCode?: string } = {}): DocumentDBClient {
-        const client = new DefaultDocumentDBClient(regionCode)
+        const client = DefaultDocumentDBClient.create(regionCode)
         client.getClient = sdkStub
         return client
     }

--- a/packages/core/src/test/shared/wizards/wizardTestUtils.ts
+++ b/packages/core/src/test/shared/wizards/wizardTestUtils.ts
@@ -65,9 +65,7 @@ function failIf(cond: boolean, message?: string): void {
 export async function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): Promise<Tester<T>> {
     if (wizard instanceof Wizard && wizard.init) {
         // Ensure that init() was called. Needed because createWizardTester() does not call run().
-        ;(wizard as any)._ready = true
         await wizard.init()
-        delete wizard.init
     }
 
     const form = wizard instanceof Wizard ? wizard.boundForm : wizard


### PR DESCRIPTION
- Refactored `CreateClusterWizard` into separate reusable classes
- Fixed bug in wizard when using nested async wizard
- Add `CreateGlobalClusterWizard` class / unit test
- Register addRegion command
- Unit tests