### PR TITLE
AD-1118: display global clusters

### DIFF
--- a/packages/core/src/docdb/explorer/dbClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbClusterNode.ts
@@ -19,6 +19,8 @@ import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { DBInstance, DocumentDBClient } from '../../shared/clients/docdbClient'
 import { DocDBContext, DocDBNodeContext } from './docdbContext'
 
+export type DBClusterRole = 'global' | 'regional' | 'primary' | 'secondary'
+
 /**
  * An AWS Explorer node representing DocumentDB clusters.
  *
@@ -31,10 +33,10 @@ export class DBClusterNode extends DBResourceNode {
     constructor(
         public readonly parent: AWSTreeNodeBase,
         readonly cluster: DBCluster,
-        client: DocumentDBClient
+        client: DocumentDBClient,
+        readonly clusterRole: DBClusterRole = 'regional'
     ) {
         super(client, cluster.DBClusterIdentifier ?? '[Cluster]', vscode.TreeItemCollapsibleState.Collapsed)
-        this.id = cluster.DBClusterIdentifier
         this.arn = cluster.DBClusterArn ?? ''
         this.name = cluster.DBClusterIdentifier ?? ''
         this.contextValue = this.getContext()
@@ -79,9 +81,9 @@ export class DBClusterNode extends DBResourceNode {
 
     public getDescription(): string | boolean {
         if (this.contextValue !== (DocDBContext.ClusterRunning as string)) {
-            return this.status!
+            return `${this.clusterRole} cluster • ${this.status}`
         }
-        return false
+        return `${this.clusterRole} cluster`
     }
 
     public async createInstance(request: CreateDBInstanceMessage): Promise<DBInstance | undefined> {

--- a/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbElasticClusterNode.ts
@@ -44,9 +44,9 @@ export class DBElasticClusterNode extends DBResourceNode {
 
     public getDescription(): string | boolean {
         if (this.contextValue !== (DocDBContext.ElasticClusterRunning as string)) {
-            return this.status!
+            return `elastic cluster • ${this.status}`
         }
-        return false
+        return 'elastic cluster'
     }
 
     public async deleteCluster(finalSnapshotId: string | undefined): Promise<DBElasticCluster | undefined> {

--- a/packages/core/src/docdb/explorer/dbGlobalClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbGlobalClusterNode.ts
@@ -1,0 +1,113 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { inspect } from 'util'
+import { makeChildrenNodes } from '../../shared/treeview/utils'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { telemetry } from '../../shared/telemetry'
+import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
+import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
+import { DBClusterNode, DBClusterRole } from './dbClusterNode'
+import { DefaultDocumentDBClient, DocumentDBClient } from '../../shared/clients/docdbClient'
+import { DBCluster, GlobalCluster, GlobalClusterMember } from '@aws-sdk/client-docdb'
+import { DBResourceNode } from './dbResourceNode'
+import { DocDBContext } from './docdbContext'
+import { copyToClipboard } from '../../shared/utilities/messages'
+
+function getRegionFromArn(arn: string) {
+    const match = arn.match(/:rds:([^:]+):.*:cluster:/)
+    return match?.at(1)
+}
+
+/**
+ * An AWS Explorer node representing DocumentDB global clusters.
+ *
+ * Contains regional clusters of a global cluster as child nodes.
+ */
+export class DBGlobalClusterNode extends DBResourceNode {
+    override name = this.cluster.GlobalClusterIdentifier!
+    override arn = this.cluster.GlobalClusterArn!
+
+    constructor(
+        public readonly parent: AWSTreeNodeBase,
+        readonly cluster: GlobalCluster,
+        private readonly clusterMap: Map<string, [DBCluster, DocumentDBClient]>,
+        client: DocumentDBClient
+    ) {
+        super(client, cluster.GlobalClusterIdentifier ?? '[Cluster]', vscode.TreeItemCollapsibleState.Collapsed)
+        this.arn = cluster.GlobalClusterArn ?? ''
+        this.name = cluster.GlobalClusterIdentifier ?? ''
+        this.contextValue = DocDBContext.Cluster
+        this.iconPath = new vscode.ThemeIcon('globe') //TODO: determine icon for global cluster
+        this.description = 'global cluster'
+        this.tooltip = `${this.name}\nEngine: ${this.cluster.EngineVersion}\nStatus: ${this.cluster.Status}`
+    }
+
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
+        return telemetry.docdb_listInstances.run(async () => {
+            return await makeChildrenNodes({
+                getChildNodes: async () => {
+                    const members = this.cluster.GlobalClusterMembers ?? []
+                    await this.getMemberClusters(members)
+
+                    const nodes = members.map((member) => {
+                        const memberRole: DBClusterRole = member.IsWriter ? 'primary' : 'secondary'
+                        const [cluster, client] = this.clusterMap.get(member.DBClusterArn!) ?? []
+                        return new DBClusterNode(this, cluster!, client!, memberRole)
+                    })
+
+                    return nodes
+                },
+                getNoChildrenPlaceholderNode: async () =>
+                    new PlaceholderNode(this, localize('AWS.explorerNode.docdb.noClusters', '[No Clusters found]')),
+                sort: (item1, item2) => {
+                    if (item1.clusterRole === 'primary') {
+                        return -1
+                    }
+                    if (item2.clusterRole === 'primary') {
+                        return 1
+                    }
+                    return item1.name.localeCompare(item2.name)
+                },
+            })
+        })
+    }
+
+    // retrieve member cluster details from other regions
+    private async getMemberClusters(members: GlobalClusterMember[]): Promise<void> {
+        await Promise.all(
+            members.map(async (member) => {
+                if (!this.clusterMap.has(member.DBClusterArn!)) {
+                    const regionCode = getRegionFromArn(member.DBClusterArn!)
+                    if (regionCode) {
+                        const client = DefaultDocumentDBClient.create(regionCode)
+                        const [cluster] = await client.listClusters(member.DBClusterArn!)
+                        this.clusterMap.set(member.DBClusterArn!, [cluster, client])
+                    }
+                }
+            })
+        )
+    }
+
+    public get status(): string | undefined {
+        return this.cluster.Status
+    }
+
+    public override copyEndpoint(): Promise<void> {
+        return copyToClipboard(this.cluster.GlobalClusterResourceId!, this.name)
+    }
+
+    public override getConsoleUrl(): vscode.Uri {
+        const region = this.regionCode
+        return vscode.Uri.parse(
+            `https://${region}.console.aws.amazon.com/docdb/home?region=${region}#global-cluster-details/${this.name}`
+        )
+    }
+
+    public [inspect.custom](): string {
+        return 'DBGlobalClusterNode'
+    }
+}

--- a/packages/core/src/docdb/explorer/dbInstanceNode.ts
+++ b/packages/core/src/docdb/explorer/dbInstanceNode.ts
@@ -25,18 +25,17 @@ export class DBInstanceNode extends DBResourceNode {
         readonly instance: DBInstance
     ) {
         super(parent.client, instance.DBInstanceIdentifier ?? '[Instance]', vscode.TreeItemCollapsibleState.None)
-        this.id = instance.DBInstanceArn
         this.description = this.makeDescription()
         this.contextValue = this.getContext()
         this.tooltip = `${this.name}\nClass: ${this.instance.DBInstanceClass}\nStatus: ${this.status}`
     }
 
     private makeDescription(): string {
-        if (this.getContext() !== DocDBContext.InstanceAvailable) {
-            return `${this.status} • ${this.instance.DBInstanceClass}`
-        }
         const type = this.instance.IsClusterWriter ? 'primary' : 'replica'
-        return `${type} • ${this.instance.DBInstanceClass}`
+        if (this.getContext() !== DocDBContext.InstanceAvailable) {
+            return `${this.status} ${type} instance`
+        }
+        return `${type} instance • ${this.instance.DBInstanceClass}`
     }
 
     private getContext(): DocDBNodeContext {

--- a/packages/core/src/docdb/explorer/docdbNode.ts
+++ b/packages/core/src/docdb/explorer/docdbNode.ts
@@ -9,10 +9,12 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../shared/treeview/utils'
-import { DocumentDBClient } from '../../shared/clients/docdbClient'
+import { DBElasticCluster, DocumentDBClient } from '../../shared/clients/docdbClient'
 import { DBClusterNode } from './dbClusterNode'
 import { DBElasticClusterNode } from './dbElasticClusterNode'
 import { telemetry } from '../../shared/telemetry'
+import { DBGlobalClusterNode } from './dbGlobalClusterNode'
+import { DBCluster } from '@aws-sdk/client-docdb'
 
 /**
  * An AWS Explorer node representing DocumentDB.
@@ -31,22 +33,48 @@ export class DocumentDBNode extends AWSTreeNodeBase {
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return telemetry.docdb_listClusters.run(async () => {
             return await makeChildrenNodes({
-                getChildNodes: async () => {
-                    const nodes = []
-                    const clusters = await this.client.listClusters()
-                    nodes.push(...clusters.map((cluster) => new DBClusterNode(this, cluster, this.client)))
-
-                    const elasticClusters = await this.client.listElasticClusters()
-                    nodes.push(
-                        ...elasticClusters.map((cluster) => new DBElasticClusterNode(this, cluster, this.client))
-                    )
-
-                    return nodes
-                },
+                getChildNodes: () => this.getClusterNodes(),
                 getNoChildrenPlaceholderNode: async () =>
                     new PlaceholderNode(this, localize('AWS.explorerNode.docdb.noClusters', '[No Clusters found]')),
+                sort: (item1, item2) => item1.name.localeCompare(item2.name),
             })
         })
+    }
+
+    private async getClusterNodes() {
+        const [globalClusters, clusters, elasticClusters] = await Promise.all([
+            this.client.listGlobalClusters(),
+            this.client.listClusters(),
+            this.client.listElasticClusters(),
+        ])
+
+        // contains clusters that are part of a global cluster
+        const globalClusterMap = new Map<string, [DBCluster, DocumentDBClient]>()
+
+        for (const globalCluster of globalClusters) {
+            for (const member of globalCluster.GlobalClusterMembers ?? []) {
+                const match = clusters.find((c) => c.DBClusterArn === member.DBClusterArn)
+                if (match?.DBClusterArn) {
+                    globalClusterMap.set(match.DBClusterArn, [match, this.client])
+                }
+            }
+        }
+
+        // contains clusters that are not part of a global cluster
+        const regionalClusters = clusters.filter((c) => !globalClusterMap.has(c.DBClusterArn!))
+
+        const nodes = []
+        nodes.push(
+            ...globalClusters.map((cluster) => new DBGlobalClusterNode(this, cluster, globalClusterMap, this.client))
+        )
+        nodes.push(...regionalClusters.map((cluster) => new DBClusterNode(this, cluster, this.client)))
+        nodes.push(
+            ...elasticClusters.map(
+                (cluster) => new DBElasticClusterNode(this, cluster as DBElasticCluster, this.client)
+            )
+        )
+
+        return nodes
     }
 
     public [inspect.custom](): string {

--- a/packages/core/src/docdb/wizards/createGlobalClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/createGlobalClusterWizard.ts
@@ -13,6 +13,8 @@ import { Wizard, WizardOptions } from '../../shared/wizards/wizard'
 import { validateClusterName } from '../utils'
 import { RegionalClusterConfiguration, RegionalClusterWizard } from './regionalClusterWizard'
 
+const DocDBGlobalHelpUrl = 'https://docs.aws.amazon.com/documentdb/latest/developerguide/global-clusters.html'
+
 export interface CreateGlobalClusterState {
     RegionCode: string
     GlobalClusterName: string
@@ -42,6 +44,7 @@ export class CreateGlobalClusterWizard extends Wizard<CreateGlobalClusterState> 
             return createRegionPrompter(regions, {
                 serviceFilter: 'docdb',
                 title: localize('AWS.docdb.addRegion.region.prompt', 'Secondary region'),
+                helpUrl: DocDBGlobalHelpUrl,
             }).transform((region) => region.id)
         })
 

--- a/packages/core/src/docdb/wizards/regionalClusterWizard.ts
+++ b/packages/core/src/docdb/wizards/regionalClusterWizard.ts
@@ -194,11 +194,11 @@ async function createInstanceClassPrompter(
 function instanceCountItems(defaultCount: number, max: number = 16): DataQuickPickItem<number>[] {
     const items = []
 
-    for (let index = 1; index <= max; index++) {
+    for (let index = 0; index <= max; index++) {
         const item: DataQuickPickItem<number> = {
             label: index.toString(),
             data: index,
-            description: index === defaultCount ? '(recommended)' : undefined,
+            description: index === 0 ? '(headless)' : index === defaultCount ? '(recommended)' : undefined,
         }
         items.push(item)
     }

--- a/packages/core/src/shared/clients/docdbClient.ts
+++ b/packages/core/src/shared/clients/docdbClient.ts
@@ -20,7 +20,7 @@ function isElasticCluster(clusterId: string | undefined): boolean | undefined {
 export const DBStorageType = { Standard: 'standard', IOpt1: 'iopt1' } as const
 
 /** A list of Amazon DocumentDB clusters. */
-export interface DBElasticCluster extends DocDBElastic.Cluster {}
+export type DBElasticCluster = DocDBElastic.Cluster & DocDBElastic.ClusterInList
 
 export interface DBInstance extends DocDB.DBInstance {
     IsClusterWriter?: boolean
@@ -113,7 +113,17 @@ export class DefaultDocumentDBClient {
         return response.DBEngineVersions ?? []
     }
 
-    public async listElasticClusters(): Promise<DBElasticCluster[]> {
+    public async listGlobalClusters(clusterId: string | undefined = undefined): Promise<DocDB.GlobalCluster[]> {
+        const input: DocDB.DescribeGlobalClustersCommandInput = {
+            Filters: [],
+            GlobalClusterIdentifier: clusterId,
+        }
+        const command = new DocDB.DescribeGlobalClustersCommand(input)
+        const response = await this.executeCommand<DocDB.DescribeGlobalClustersCommandOutput>(command)
+        return response.GlobalClusters ?? []
+    }
+
+    public async listElasticClusters(): Promise<DocDBElastic.ClusterInList[]> {
         const command = new DocDBElastic.ListClustersCommand()
         const response = await this.executeElasticCommand<DocDBElastic.ListClustersCommandOutput>(command)
         return response.clusters ?? []

--- a/packages/core/src/test/docdb/commands/addRegion.test.ts
+++ b/packages/core/src/test/docdb/commands/addRegion.test.ts
@@ -67,7 +67,11 @@ describe('addRegionCommand', function () {
 
         getTestWindow().onDidShowQuickPick(async (picker) => {
             await picker.untilReady()
-            picker.acceptItem(picker.items[0])
+            if (picker.title?.includes('instances')) {
+                picker.acceptItem(picker.items[1])
+            } else {
+                picker.acceptItem(picker.items[0])
+            }
         })
     }
 

--- a/packages/core/src/test/docdb/commands/createCluster.test.ts
+++ b/packages/core/src/test/docdb/commands/createCluster.test.ts
@@ -56,7 +56,11 @@ describe('createClusterCommand', function () {
 
         getTestWindow().onDidShowQuickPick(async (picker) => {
             await picker.untilReady()
-            picker.acceptItem(picker.items[0])
+            if (picker.title?.includes('instances')) {
+                picker.acceptItem(picker.items[1])
+            } else {
+                picker.acceptItem(picker.items[0])
+            }
         })
     }
 

--- a/packages/core/src/test/docdb/commands/deleteCluster.test.ts
+++ b/packages/core/src/test/docdb/commands/deleteCluster.test.ts
@@ -151,7 +151,7 @@ describe('deleteClusterCommand', function () {
     })
 
     describe('elastic cluster', function () {
-        let cluster: DBElasticCluster
+        let cluster: any
         let node: DBElasticClusterNode
 
         beforeEach(function () {

--- a/packages/core/src/test/docdb/explorer/docdbNode.test.ts
+++ b/packages/core/src/test/docdb/explorer/docdbNode.test.ts
@@ -6,7 +6,7 @@
 import sinon from 'sinon'
 import assert from 'assert'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
-import { DBElasticCluster, DocumentDBClient } from '../../../shared/clients/docdbClient'
+import { DocumentDBClient } from '../../../shared/clients/docdbClient'
 import { DBCluster } from '@aws-sdk/client-docdb'
 import { DBClusterNode } from '../../../docdb/explorer/dbClusterNode'
 import { DocumentDBNode } from '../../../docdb/explorer/docdbNode'
@@ -15,7 +15,7 @@ import { DBElasticClusterNode } from '../../../docdb/explorer/dbElasticClusterNo
 describe('DocumentDBNode', function () {
     const firstCluster: DBCluster = { DBClusterIdentifier: 'Cluster-1' }
     const secondCluster: DBCluster = { DBClusterIdentifier: 'Cluster-2' }
-    const thirdCluster: DBElasticCluster = { clusterName: 'Cluster-3', clusterArn: '', status: 'ACTIVE' }
+    const thirdCluster = { clusterName: 'Cluster-3', clusterArn: '', status: 'ACTIVE' }
 
     let client: DocumentDBClient
 
@@ -31,6 +31,7 @@ describe('DocumentDBNode', function () {
     it('gets children', async function () {
         client.listClusters = sinon.stub().resolves([firstCluster, secondCluster])
         client.listElasticClusters = sinon.stub().resolves([thirdCluster])
+        client.listGlobalClusters = sinon.stub().resolves([])
 
         const node = new DocumentDBNode(client)
         const [firstClusterNode, secondClusterNode, thirdClusterNode, ...otherNodes] = await node.getChildren()


### PR DESCRIPTION
- Include global clusters in root node
- Nest primary and secondary clusters underneath global cluster node
- Update description to include role and type
- Update unit tests
- Allow 0 instances to be created when creating a new cluster