### PR TITLE
Fix polling mechanism for DocDB explorer

### DIFF
--- a/packages/core/src/docdb/activation.ts
+++ b/packages/core/src/docdb/activation.ts
@@ -23,56 +23,78 @@ import { renameInstance } from './commands/renameInstance'
 import { addTag, listTags, removeTag } from './commands/tagCommands'
 import { Uri } from 'vscode'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
+import { getLogger } from '../shared/logger'
+
+/**
+ * A utility function to automatically invoke trackChanges after a command.
+ */
+
+function withTrackChanges<T extends DBResourceNode>(
+    command: (node: T) => Promise<void>,
+    commandName: string = 'UnnamedCommand'
+): (node: T) => Promise<void> {
+    return async (node: T) => {
+        const arn = node.arn || 'UnknownARN'
+        const startTime = new Date().toISOString()
+
+        getLogger().info(
+            `[${startTime}] Executing command "${commandName}" for resource with ARN: ${arn}. Tracking changes will be invoked post-execution.`
+        )
+
+        await command(node)
+
+        const endTime = new Date().toISOString()
+        getLogger().info(
+            `[${endTime}] Successfully executed command "${commandName}" for resource with ARN: ${arn}. Invoking trackChanges now.`
+        )
+
+        await node.trackChangesWithWaitProcessingStatus()
+    }
+}
 
 /**
  * Activates DocumentDB components.
  */
-
 export async function activate(ctx: ExtContext): Promise<void> {
     ctx.extensionContext.subscriptions.push(
         Commands.register('aws.docdb.createCluster', async (node?: DocumentDBNode) => {
             await createCluster(node)
         }),
 
-        Commands.register('aws.docdb.deleteCluster', async (node: DBClusterNode) => {
-            await deleteCluster(node)
-        }),
+        Commands.register('aws.docdb.deleteCluster', withTrackChanges<DBClusterNode>(deleteCluster, 'deleteCluster')),
 
-        Commands.register('aws.docdb.renameCluster', async (node: DBClusterNode) => {
-            await renameCluster(node)
-        }),
+        Commands.register('aws.docdb.renameCluster', withTrackChanges<DBClusterNode>(renameCluster, 'renameCluster')),
 
-        Commands.register('aws.docdb.startCluster', async (node?: DBClusterNode) => {
-            await startCluster(node)
-        }),
+        Commands.register('aws.docdb.startCluster', withTrackChanges<DBClusterNode>(startCluster, 'startCluster')),
 
-        Commands.register('aws.docdb.stopCluster', async (node?: DBClusterNode) => {
-            await stopCluster(node)
-        }),
+        Commands.register('aws.docdb.stopCluster', withTrackChanges<DBClusterNode>(stopCluster, 'stopCluster')),
 
-        Commands.register('aws.docdb.addRegion', async (node: DBClusterNode) => {
-            await addRegion(node)
-        }),
+        Commands.register('aws.docdb.addRegion', withTrackChanges<DBClusterNode>(addRegion, 'addRegion')),
 
-        Commands.register('aws.docdb.createInstance', async (node: DBClusterNode) => {
-            await createInstance(node)
-        }),
+        Commands.register(
+            'aws.docdb.createInstance',
+            withTrackChanges<DBClusterNode>(createInstance, 'createInstance')
+        ),
 
-        Commands.register('aws.docdb.deleteInstance', async (node: DBInstanceNode) => {
-            await deleteInstance(node)
-        }),
+        Commands.register(
+            'aws.docdb.deleteInstance',
+            withTrackChanges<DBInstanceNode>(deleteInstance, 'deleteInstance')
+        ),
 
-        Commands.register('aws.docdb.modifyInstance', async (node: DBInstanceNode) => {
-            await modifyInstance(node)
-        }),
+        Commands.register(
+            'aws.docdb.modifyInstance',
+            withTrackChanges<DBInstanceNode>(modifyInstance, 'modifyInstance')
+        ),
 
-        Commands.register('aws.docdb.rebootInstance', async (node: DBInstanceNode) => {
-            await rebootInstance(node)
-        }),
+        Commands.register(
+            'aws.docdb.rebootInstance',
+            withTrackChanges<DBInstanceNode>(rebootInstance, 'rebootInstance')
+        ),
 
-        Commands.register('aws.docdb.renameInstance', async (node: DBInstanceNode) => {
-            await renameInstance(node)
-        }),
+        Commands.register(
+            'aws.docdb.renameInstance',
+            withTrackChanges<DBInstanceNode>(renameInstance, 'renameInstance')
+        ),
 
         Commands.register('aws.docdb.listTags', async (node: DBResourceNode) => {
             await listTags(node)
@@ -90,7 +112,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
             await node?.openInBrowser()
         }),
 
-        Commands.register('aws.docdb.viewDocs', async (node?: DBResourceNode) => {
+        Commands.register('aws.docdb.viewDocs', async () => {
             await openUrl(
                 Uri.parse('https://docs.aws.amazon.com/documentdb/latest/developerguide/get-started-guide.html')
             )

--- a/packages/core/src/docdb/explorer/dbGlobalClusterNode.ts
+++ b/packages/core/src/docdb/explorer/dbGlobalClusterNode.ts
@@ -17,6 +17,7 @@ import { DBResourceNode } from './dbResourceNode'
 import { DocDBContext } from './docdbContext'
 import { copyToClipboard } from '../../shared/utilities/messages'
 import { getAwsConsoleUrl } from '../../shared/awsConsole'
+import { getLogger } from '../../shared/logger'
 
 function getRegionFromArn(arn: string) {
     const match = arn.match(/:rds:([^:]+):.*:cluster:/)
@@ -46,6 +47,12 @@ export class DBGlobalClusterNode extends DBResourceNode {
         this.iconPath = new vscode.ThemeIcon('globe') //TODO: determine icon for global cluster
         this.description = 'Global cluster'
         this.tooltip = `${this.name}\nEngine: ${this.cluster.EngineVersion}\nStatus: ${this.cluster.Status} (read-only)`
+        if (this.isStatusRequiringPolling()) {
+            getLogger().info(`${this.arn} requires polling.`)
+            this.trackChanges()
+        } else {
+            getLogger().info(`${this.arn} does NOT require polling.`)
+        }
     }
 
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/packages/core/src/docdb/explorer/docdbNode.ts
+++ b/packages/core/src/docdb/explorer/docdbNode.ts
@@ -25,7 +25,6 @@ import { DBResourceNode } from './dbResourceNode'
  */
 export class DocumentDBNode extends AWSTreeNodeBase {
     public override readonly regionCode: string
-    private allNodes: DBResourceNode[] = []
 
     public constructor(public readonly client: DocumentDBClient) {
         super('DocumentDB', vscode.TreeItemCollapsibleState.Collapsed)
@@ -67,9 +66,6 @@ export class DocumentDBNode extends AWSTreeNodeBase {
 
         // contains clusters that are not part of a global cluster
         const regionalClusters = clusters.filter((c) => !globalClusterMap.has(c.DBClusterArn!))
-        this.allNodes.forEach((node) => {
-            node.clearTimer()
-        })
 
         const nodes: DBResourceNode[] = []
         nodes.push(
@@ -82,7 +78,7 @@ export class DocumentDBNode extends AWSTreeNodeBase {
                 (cluster) => new DBElasticClusterNode(this, cluster as DBElasticCluster, this.client)
             )
         )
-        this.allNodes = nodes
+
         return nodes
     }
 


### PR DESCRIPTION
## Problem
DocDb polling mechanism for the explorer was operating as intended 

## Solution

1. Set the polling interval to 30 seconds.
2. Since instances of `ResourceNode` are created at arbitrary times, added conditions to track changes in the constructors.
3. As `pollingSet` is an instance property, introduced a static global set of records for ARNs to track which resources are currently being polled.
4. Updated the polling logic to check against processingStates (specifically `'creating', 'modifying', 'rebooting', 'starting', 'stopping', 'renaming'`) to determine whether an instance requires polling.
5. Removed unnecessary stop timer commands.
6. Performed some refactoring for improved code clarity.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
